### PR TITLE
Install cmake with mamba

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,16 +28,7 @@ RUN wget -q \
 RUN mamba --version
 
 # Step 2: get an up-to date cmake (HEREDOC needs DOCKER_BUILDKIT=1 enabled or build with "docker buildx")
-RUN <<-EOF
-    cmake_ubuntu_version=$(lsb_release -cs)
-    if ! wget -q --method=HEAD "https://apt.kitware.com/ubuntu/dists/$cmake_ubuntu_version/Release"; then
-      bash -c "$(wget -O - https://apt.kitware.com/kitware-archive.sh)"
-    else
-      wget -qO - https://apt.kitware.com/kitware-archive.sh | bash -s -- --release $cmake_ubuntu_version
-    fi
-    apt-get -y update
-    apt-get install -y cmake
-EOF
+RUN mamba install cmake
 
 # Step 3: dependencies for contrib etc.
 RUN apt-get install -y --no-install-recommends --no-install-suggests libsvm-dev libglpk-dev libzip-dev zlib1g-dev libxerces-c-dev libbz2-dev libomp-dev libhdf5-dev


### PR DESCRIPTION
While testing the Dockerfile installation of cmake failed. Mamba offers up-to-date cmake, this should be simpler and more reliable.