### PR TITLE
Remove unused OpenMS bin and share artifacts

### DIFF
--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -229,6 +229,16 @@ jobs:
         call myenv\Scripts\activate.bat
         pyinstaller run_app.spec --clean
 
+    - name: Delete OpenMS bin artifact
+    - uses: geekyeggo/delete-artifact@v2
+      with:
+          name: OpenMS-bin
+
+    - name: Delete OpenMS share artifact
+    - uses: geekyeggo/delete-artifact@v2
+      with:
+          name: OpenMS-share
+
     - name: Upload artifact
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -230,12 +230,12 @@ jobs:
         pyinstaller run_app.spec --clean
 
     - name: Delete OpenMS bin artifact
-    - uses: geekyeggo/delete-artifact@v2
+      uses: geekyeggo/delete-artifact@v2
       with:
           name: OpenMS-bin
 
     - name: Delete OpenMS share artifact
-    - uses: geekyeggo/delete-artifact@v2
+      uses: geekyeggo/delete-artifact@v2
       with:
           name: OpenMS-share
 


### PR DESCRIPTION
OpenMS bin and share directories are transferred between jobs by uploading and downloading as artifacts.
However, we only need the final package available as artifact so bin and share get deleted now.