### PR TITLE
Downloadable Windows executable

### DIFF
--- a/Dockerfile_simple
+++ b/Dockerfile_simple
@@ -1,7 +1,7 @@
 # This Dockerfile creates a container with pyOpenMS
 # It also adds a basic streamlit server that serves a pyOpenMS-based app.
 # hints:
-# build image with: docker build -f Dockerfile_simple --no-cache -t streamlitapp:latest . 2>&1 | tee build.log
+# build image with: docker build -f Dockerfile_simple --no-cache -t streamlitapp:latest --build-arg GITHUB_TOKEN=<your-github-token> . 2>&1 | tee build.log
 # check if image was build: docker image ls
 # run container: docker run -p 8501:8501 streamlitapp:latest
 # debug container after build (comment out ENTRYPOINT) and run container with interactive /bin/bash shell
@@ -11,13 +11,20 @@ FROM ubuntu:22.04 AS stage1
 ARG OPENMS_REPO=https://github.com/OpenMS/OpenMS.git
 ARG OPENMS_BRANCH=develop
 ARG PORT=8501
+# GitHub token to download latest OpenMS executable for Windows from Github action artifact.
+ARG GITHUB_TOKEN
+# Streamlit app Gihub user name (to download artifact from).
+ARG GITHUB_USER=OpenMS
+# Streamlit app Gihub repository name (to download artifact from).
+ARG GITHUB_REPO=streamlit-template
+
 
 # Step 1: set up a sane build system
 USER root
 
 RUN apt-get -y update
 # note: streamlit in docker needs libgtk2.0-dev (see https://yugdamor.medium.com/importerror-libgthread-2-0-so-0-cannot-open-shared-object-file-no-such-file-or-directory-895b94a7827b)
-RUN apt-get install -y --no-install-recommends --no-install-suggests wget ca-certificates libgtk2.0-dev
+RUN apt-get install -y --no-install-recommends --no-install-suggests wget ca-certificates libgtk2.0-dev curl jq
 RUN update-ca-certificates
 
 # Install mamba (faster than conda)
@@ -52,6 +59,12 @@ COPY pages/ /app/pages
 
 # install cron (TODO: think about automatic clean up of temporary files and workspaces)
 # RUN apt-get install -y cron
+
+# Download latest OpenMS App executable for Windows from Github actions workflow.
+RUN WORKFLOW_ID=$(curl -s "https://api.github.com/repos/$GITHUB_USER/$GITHUB_REPO/actions/workflows" | jq -r '.workflows[] | select(.name == "Build executable for Windows") | .id') \
+    && SUCCESSFUL_RUNS=$(curl -s "https://api.github.com/repos/$GITHUB_USER/$GITHUB_REPO/actions/runs?workflow_id=$WORKFLOW_ID&status=success" | jq -r '.workflow_runs[0].id') \
+    && ARTIFACT_ID=$(curl -s "https://api.github.com/repos/$GITHUB_USER/$GITHUB_REPO/actions/runs/$SUCCESSFUL_RUNS/artifacts" | jq -r '.artifacts[] | select(.name == "OpenMS-App") | .id') \
+    && curl -LJO -H "Authorization: Bearer $GITHUB_TOKEN" "https://api.github.com/repos/$GITHUB_USER/$GITHUB_REPO/actions/artifacts/$ARTIFACT_ID/zip" -o /app/OpenMS-App
 
 # make sure that mamba environment is used
 SHELL ["mamba", "run", "-n", "streamlit-env", "/bin/bash", "-c"]

--- a/app.py
+++ b/app.py
@@ -1,16 +1,22 @@
 import streamlit as st
 from src.common import *
 from streamlit.web import cli
-
+from pathlib import Path
 
 params = page_setup(page="main")
 
 if __name__ == "__main__":
-    st.markdown(
-        """# Template App
-
-    A template for an OpenMS streamlit app."""
-    )
+    st.title("Template App")
+    st.markdown("## A template for an OpenMS streamlit app.")
+    if Path("OpenMS-App.zip").exists():
+        st.markdown("## Installation")
+        with open("OpenMS-App.zip", "rb") as file:
+            st.download_button(
+                    label="Download for Windows",
+                    data=file,
+                    file_name="OpenMS-App.zip",
+                    mime="archive/zip",
+                )
 
 save_params(params)
 


### PR DESCRIPTION
During the Docker build the Windows executable zip file, provided by a Github action, gets downloaded into the docker container. The user can download it directly from the app.
In order for this to work, a valid Github token needs to be provided as argument to docker build.