### PR TITLE
contrib-build from OpenMS/contrib release

### DIFF
--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -63,12 +63,16 @@ jobs:
         key: ${{ runner.os }}-contrib3
 
     - name: Load contrib build
-      if: steps.cache-contrib-win.outputs.cache-hit != 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-          cd OpenMS/contrib
-          curl -o contribbld.tar.gz https://abibuilder.cs.uni-tuebingen.de/archive/openms/contrib/windows/x64/msvc-14.2/contrib_build.tar.gz
-          tar -xzf contribbld.tar.gz
-          rm contribbld.tar.gz
+        cd OpenMS/contrib
+        # Download the file using the URL fetched from GitHub
+        gh release download -R OpenMS/contrib --pattern 'contrib_build-Windows.tar.gz'
+        # Extract the archive
+        7z x -so contrib_build-Windows.tar.gz | 7z x -si -ttar
+        rm contrib_build-Windows.tar.gz
+        ls
 
     - name: Setup ccache cache
       uses: actions/cache@v3


### PR DESCRIPTION
### **User description**
- not needed abibuilder contrib anymore


___

### **PR Type**
enhancement


___

### **Description**
- Updated the GitHub Actions workflow for building Windows executables to use GitHub's release feature for downloading dependencies.
- This change includes the use of `gh release download` for fetching the `contrib_build-Windows.tar.gz` file and `7z` for extraction, replacing the previous use of `curl` and `tar`.
- Added `GITHUB_TOKEN` as an environment variable to authenticate GitHub CLI operations.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build-windows-executable-app.yaml</strong><dd><code>Update Windows Executable Build Process in GitHub Actions</code></dd></summary>
<hr>
      
.github/workflows/build-windows-executable-app.yaml

<li>Added environment variable <code>GITHUB_TOKEN</code> for authentication.<br> <li> Changed the method of downloading the contrib build using GitHub's <br>release feature instead of a direct URL.<br> <li> Replaced <code>curl</code> and <code>tar</code> commands with <code>gh release download</code> and <code>7z</code> <br>commands for handling the download and extraction of files.<br>


</details>
    

  </td>
  <td><a href="https://github.com/OpenMS/streamlit-template/pull/55/files#diff-211d58f377673fc6e00e49835e1cf5dc727c333368e2b5f8f1cf31e1eff077c5">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

