### PR TITLE
Print error info to stdout when we can't parse parameter

### DIFF
--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -514,8 +514,9 @@ class StreamlitUI:
                 if i == num_cols:
                     i = 0
                     cols = st.columns(num_cols)
-            except:
+            except Exception as e:
                 cols[i].error(f"Error in parameter **{p['name']}**.")
+                print("Error parsing \""+ p['name'] + "\": " + str(e))
 
     def input_python(
         self,


### PR DESCRIPTION
### **User description**
Print some more info when we fail to parse a parameter out of a TOPP tool


___

### **PR Type**
bug_fix


___

### **Description**
- Enhanced error reporting in `StreamlitUI` by capturing exceptions and printing detailed error messages to stdout. This helps in debugging issues related to parameter parsing in TOPP tools.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>StreamlitUI.py</strong><dd><code>Enhance error reporting in StreamlitUI parameter parsing</code>&nbsp; </dd></summary>
<hr>
      
src/workflow/StreamlitUI.py

<li>Added exception handling to output error details to stdout when a <br>parameter parsing fails.<br>


</details>
    

  </td>
  <td><a href="https://github.com/OpenMS/streamlit-template/pull/58/files#diff-d2d8b6f64f15e9961120b170f519cff4a534717079fb0ab30a47afffa4a4daa7">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

