### PR TITLE
Add Download Page

### DIFF
--- a/pages/16_Download_Section.py
+++ b/pages/16_Download_Section.py
@@ -1,0 +1,64 @@
+import streamlit as st
+
+from os.path import join, exists, isfile, basename
+from os import listdir
+
+from src.common import page_setup
+from io import StringIO, BytesIO
+from zipfile import ZipFile, ZIP_DEFLATED
+
+# Define output folder here; all subfolders will be handled as downloadable
+# directories
+output_folder = 'your_folder_goes_here'
+
+def content():
+    page_setup()
+
+    dirpath = join(st.session_state["workspace"], output_folder)
+
+    if exists(dirpath):
+        directories = sorted(
+            [entry for entry in listdir(dirpath) if not isfile(entry)]
+        )
+    else:
+        directories = []
+
+    if len(directories) == 0:
+        st.error('No results to show yet. Please run a workflow first!')
+        return
+    
+    # Table Header
+    columns = st.columns((0.4, 0.6))
+    columns[0].write('**Run**')
+    columns[1].write('**Download**')
+
+    # Table Body
+    for i, directory in enumerate(directories):
+        st.divider()
+        columns = st.columns((0.4, 0.6))
+        columns[0].empty().write(directory)
+        
+        with columns[1]:
+            button_placeholder = st.empty()
+            
+            clicked = button_placeholder.button('Prepare Download', key=i)
+            if clicked:
+                button_placeholder.empty()
+                with st.spinner():
+                    out_zip = join(dirpath, directory, 'output.zip')
+                    if not exists(out_zip):
+                        with ZipFile(out_zip, 'w', ZIP_DEFLATED) as zip_file:
+                            for output in listdir(join(dirpath, directory)):
+                                try:
+                                    with open(join(dirpath, directory, output), 'r') as f:
+                                        zip_file.writestr(basename(output), f.read())
+                                except:
+                                    continue
+                    with open(out_zip, 'rb') as f:
+                        button_placeholder.download_button(
+                            "Download ⬇️", f, 
+                            file_name = f'{directory}.zip'
+                        )
+
+if __name__ == "__main__":
+    content()

--- a/pages/16_Download_Section.py
+++ b/pages/16_Download_Section.py
@@ -14,8 +14,10 @@ output_folder = 'your_folder_goes_here'
 def content():
     page_setup()
 
+    # Generate full path
     dirpath = join(st.session_state["workspace"], output_folder)
-
+    
+    # Detect downloadable content
     if exists(dirpath):
         directories = sorted(
             [entry for entry in listdir(dirpath) if not isfile(entry)]
@@ -23,6 +25,7 @@ def content():
     else:
         directories = []
 
+    # Show error if no content is available for download
     if len(directories) == 0:
         st.error('No results to show yet. Please run a workflow first!')
         return
@@ -41,10 +44,12 @@ def content():
         with columns[1]:
             button_placeholder = st.empty()
             
+            # Show placeholder button before download is prepared
             clicked = button_placeholder.button('Prepare Download', key=i)
             if clicked:
                 button_placeholder.empty()
                 with st.spinner():
+                    # Create ZIP file
                     out_zip = join(dirpath, directory, 'output.zip')
                     if not exists(out_zip):
                         with ZipFile(out_zip, 'w', ZIP_DEFLATED) as zip_file:
@@ -54,6 +59,7 @@ def content():
                                         zip_file.writestr(basename(output), f.read())
                                 except:
                                     continue
+                    # Show download button after ZIP file was created
                     with open(out_zip, 'rb') as f:
                         button_placeholder.download_button(
                             "Download ⬇️", f, 


### PR DESCRIPTION
### **User description**
This PR adds a download page to give the user the option to download the results generated as a zip file.

Fixes #53.

Developers simply have to specify a folder in the workspace, where all output is saved. Each run should be saved in a different subfolder. For instance, consider these folder locations for `output_folder="output_folder"`:

`workspace/output_folder/run_1/`
`workspace/output_folder/run_2/`
`workspace/output_folder/run_3/`

This would result in three download options: `run_1`, `run_2`, and `run_3`.

Downloads are prepared on demand. The zip file is only created when the `Prepare Download` button is clicked.

In `FLASHViewer` it looks like this:

<img width="1095" alt="image" src="https://github.com/OpenMS/streamlit-template/assets/57191390/d2a8ead9-3249-4b45-9d2d-30c0b6999bde">


___

### **PR Type**
Enhancement


___

### **Description**
- Added a new download page to the application, allowing users to download results as zip files.
- Implemented directory listing and zip file preparation functionality.
- Included error handling for cases where no results are available.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>16_Download_Section.py</strong><dd><code>Add download page for exporting results as zip files</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
pages/16_Download_Section.py

<li>Added a new page for downloading results as zip files.<br> <li> Implemented a function to list directories and prepare zip files for <br>download.<br> <li> Included error handling for missing directories and empty results.<br>


</details>
    

  </td>
  <td><a href="https://github.com/OpenMS/streamlit-template/pull/71/files#diff-ceb6d4f1d1798651fb27fa657d9a68f3085596e8d3b3b7e62e0c995e00426a79">+64/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

