### PR TITLE
update: upload_widget

### DIFF
--- a/content/file_upload.py
+++ b/content/file_upload.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import streamlit as st
 import pandas as pd
 
-from src.common import page_setup, save_params, v_space, show_table
+from src.common import page_setup, save_params, v_space, show_table, TK_AVAILABLE, tk_directory_dialog
 from src import fileupload
 
 params = page_setup()
@@ -38,21 +38,45 @@ with tabs[1]:
 # Local file upload option: via directory path
 if st.session_state.location == "local":
     with tabs[2]:
-        # with st.form("local-file-upload"):
-        local_mzML_dir = st.text_input("path to folder with mzML files")
+        st_cols = st.columns([0.05, 0.95], gap="small")
+        with st_cols[0]:
+            st.write("\n")
+            st.write("\n")
+            dialog_button = st.button("📁", key='local_browse', help="Browse for your local directory with MS data.", disabled=not TK_AVAILABLE)
+            if dialog_button:
+                st.session_state["local_dir"] = tk_directory_dialog("Select directory with your MS data", st.session_state["previous_dir"])
+                st.session_state["previous_dir"] = st.session_state["local_dir"]
+        with st_cols[1]:
+            # with st.form("local-file-upload"):
+            local_mzML_dir = st.text_input("path to folder with mzML files", value=st.session_state["local_dir"])
         # raw string for file paths
         local_mzML_dir = rf"{local_mzML_dir}"
-        cols = st.columns(3)
-        if cols[1].button(
-            "Copy files to workspace", type="primary", disabled=(local_mzML_dir == "")
-        ):
-            fileupload.copy_local_mzML_files_from_directory(local_mzML_dir)
+        cols = st.columns([0.65, 0.3, 0.4, 0.25], gap="small")
+        copy_button = cols[1].button("Copy files to workspace", type="primary", disabled=(local_mzML_dir == ""))
+        use_copy = cols[2].checkbox("Make a copy of files", key="local_browse-copy_files", value=True, help="Create a copy of files in workspace.")
+        if not use_copy:
+                st.warning(
+        "**Warning**: You have deselected the `Make a copy of files` option. "
+        "This **_assumes you know what you are doing_**. "
+        "This means that the original files will be used instead. "
+    )
+        if copy_button:
+            fileupload.copy_local_mzML_files_from_directory(local_mzML_dir, use_copy)
 
 mzML_dir = Path(st.session_state.workspace, "mzML-files")
 if any(Path(mzML_dir).iterdir()):
     v_space(2)
     # Display all mzML files currently in workspace
-    df = pd.DataFrame({"file name": [f.name for f in Path(mzML_dir).iterdir()]})
+    df = pd.DataFrame({"file name": [f.name for f in Path(mzML_dir).iterdir() if "external_files.txt" not in f.name]})
+    
+    # Check if local files are available
+    external_files = Path(mzML_dir, "external_files.txt")
+    if external_files.exists():
+        with open(external_files, "r") as f_handle:
+            external_files = f_handle.readlines()
+            external_files = [f.strip() for f in external_files]
+            df = pd.concat([df, pd.DataFrame({"file name": external_files})], ignore_index=True)
+    
     st.markdown("##### mzML files in current workspace:")
     show_table(df)
     v_space(1)

--- a/content/raw_data_viewer.py
+++ b/content/raw_data_viewer.py
@@ -12,9 +12,21 @@ st.title("View raw MS data")
 
 # File selection can not be in fragment since it influences the subsequent sections
 cols = st.columns(3)
+
+mzML_dir = Path(st.session_state.workspace, "mzML-files")
+file_options = [f.name for f in mzML_dir.iterdir() if "external_files.txt" not in f.name]
+
+# Check if local files are available
+external_files = Path(mzML_dir, "external_files.txt")
+if external_files.exists():
+    with open(external_files, "r") as f_handle:
+        external_files = f_handle.readlines()
+        external_files = [f.strip() for f in external_files]
+        file_options += external_files
+
 selected_file = cols[0].selectbox(
     "choose file",
-    [f.name for f in Path(st.session_state.workspace, "mzML-files").iterdir()],
+    file_options,
     key="view_selected_file"
 )
 if selected_file:

--- a/content/run_example_workflow.py
+++ b/content/run_example_workflow.py
@@ -20,9 +20,20 @@ This is great for large parameter sections.
 
 with st.form("workflow-with-mzML-form"):
     st.markdown("**Parameters**")
+    
+    file_options = [f.stem for f in Path(st.session_state.workspace, "mzML-files").glob("*.mzML") if "external_files.txt" not in f.name]
+    
+    # Check if local files are available
+    external_files = Path(Path(st.session_state.workspace, "mzML-files"), "external_files.txt")
+    if external_files.exists():
+        with open(external_files, "r") as f_handle:
+            external_files = f_handle.readlines()
+            external_files = [str(Path(f.strip()).with_suffix('')) for f in external_files]
+            file_options += external_files
+
     st.multiselect(
         "**input mzML files**",
-        [f.stem for f in Path(st.session_state.workspace, "mzML-files").glob("*.mzML")],
+        file_options,
         params["example-workflow-selected-mzML-files"],
         key="example-workflow-selected-mzML-files",
     )

--- a/src/Workflow.py
+++ b/src/Workflow.py
@@ -22,7 +22,7 @@ class Workflow(WorkflowManager):
             self.ui.upload_widget(
                 key="mzML-files",
                 name="MS data",
-                file_type="mzML",
+                file_types="mzML",
                 fallback=[str(f) for f in Path("example-data", "mzML").glob("*.mzML")],
             )
 

--- a/src/common.py
+++ b/src/common.py
@@ -385,6 +385,31 @@ def tk_directory_dialog(title: str = "Select Directory", parent_dir: str = os.ge
         root.destroy()
         return file_path
 
+def tk_file_dialog(title: str = "Select File", file_types: list[tuple] = [], parent_dir: str = os.getcwd(), multiple:bool = True):
+    """
+    Creates a Tkinter file dialog for selecting a file.
+
+    Args:
+        title (str): The title of the file dialog.
+        file_types (list(tuple)): The file types to filter the file dialog.
+        parent_dir (str): The path to the parent directory of the file dialog.
+        multiple (bool): If True, multiple files can be selected.
+
+    Returns:
+        str: The path to the selected file.
+    
+    Warning:
+        This function is not avaliable in a streamlit cloud context.
+    """
+    root = Tk()
+    root.attributes("-topmost", True)
+    root.withdraw()
+    file_types.extend([("All files", "*.*")])
+    file_path = filedialog.askopenfilename(
+        title=title, filetypes=file_types, initialdir=parent_dir, multiple=True
+    )
+    root.destroy()
+    return file_path
 
 # General warning/error messages
 WARNINGS = {

--- a/src/common.py
+++ b/src/common.py
@@ -9,6 +9,12 @@ from pathlib import Path
 import streamlit as st
 import pandas as pd
 
+try:
+    from tkinter import Tk, filedialog
+    TK_AVAILABLE = True
+except ImportError:
+    TK_AVAILABLE = False
+
 from .captcha_ import captcha_control
 
 # set these variables according to your project
@@ -358,6 +364,27 @@ def reset_directory(path: Path) -> None:
         shutil.rmtree(path)
     path.mkdir(parents=True, exist_ok=True)
 
+def tk_directory_dialog(title: str = "Select Directory", parent_dir: str = os.getcwd()):
+        """
+        Creates a Tkinter directory dialog for selecting a directory.
+
+        Args:
+            title (str): The title of the directory dialog.
+            parent_dir (str): The path to the parent directory of the directory dialog.
+
+        Returns:
+            str: The path to the selected directory.
+        
+        Warning:
+            This function is not avaliable in a streamlit cloud context.
+        """
+        root = Tk()
+        root.attributes("-topmost", True)
+        root.withdraw()
+        file_path = filedialog.askdirectory(title=title, initialdir=parent_dir)
+        root.destroy()
+        return file_path
+
 
 # General warning/error messages
 WARNINGS = {
@@ -369,3 +396,4 @@ ERRORS = {
     "workflow": "Something went wrong during workflow execution.",
     "visualization": "Something went wrong during visualization of results.",
 }
+

--- a/src/common.py
+++ b/src/common.py
@@ -114,6 +114,8 @@ def page_setup(page: str = "") -> dict[str, Any]:
         # Check location
         if "local" in sys.argv:
             st.session_state.location = "local"
+            st.session_state["previous_dir"] = os.getcwd()
+            st.session_state["local_dir"] = ""
         else:
             st.session_state.location = "online"
         # if we run the packaged windows version, we start within the Python directory -> need to change working directory to ..\streamlit-template

--- a/src/common.py
+++ b/src/common.py
@@ -15,6 +15,9 @@ from .captcha_ import captcha_control
 APP_NAME = "OpenMS Streamlit App"
 REPOSITORY_NAME = "streamlit-template"
 
+# Detect system platform
+OS_PLATFORM = sys.platform
+
 
 def load_params(default: bool = False) -> dict[str, Any]:
     """

--- a/src/fileupload.py
+++ b/src/fileupload.py
@@ -35,12 +35,13 @@ def save_uploaded_mzML(uploaded_files: list[bytes]) -> None:
     st.success("Successfully added uploaded files!")
 
 
-def copy_local_mzML_files_from_directory(local_mzML_directory: str) -> None:
+def copy_local_mzML_files_from_directory(local_mzML_directory: str, make_copy: bool=True) -> None:
     """
     Copies local mzML files from a specified directory to the mzML directory.
 
     Args:
         local_mzML_directory (str): Path to the directory containing the mzML files.
+        make_copy (bool): Whether to make a copy of the files in the workspace. Default is True. If False, local file paths will be written to an external_files.txt file.
 
     Returns:
         None
@@ -53,7 +54,18 @@ def copy_local_mzML_files_from_directory(local_mzML_directory: str) -> None:
     # Copy all mzML files to workspace mzML directory, add to selected files
     files = Path(local_mzML_directory).glob("*.mzML")
     for f in files:
-        shutil.copy(f, Path(mzML_dir, f.name))
+        if make_copy:
+            shutil.copy(f, Path(mzML_dir, f.name))
+        else:
+            # Create a temporary file to store the path to the local directories
+            external_files = Path(mzML_dir, "external_files.txt")
+            # Check if the file exists, if not create it
+            if not external_files.exists():
+                external_files.touch()
+            # Write the path to the local directories to the file
+            with open(external_files, "a") as f_handle:
+                f_handle.write(f"{f}\n")
+                
     st.success("Successfully added local files!")
 
 

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -47,7 +47,7 @@ class StreamlitUI:
             file_types (Union[str, List[str]]): Expected file type(s) for the uploaded files.
             name (str, optional): Display name for the upload component. Defaults to the key if not provided.
             fallback (Union[List, str], optional): Default files to use if no files are uploaded.
-            symlink (bool, optional): Whether to symlink the uploaded files. This is used if local to avoid making duplicate copies. Defaults to True.
+            symlink (bool, optional): Whether to symlink the uploaded files. This is used if local to avoid making duplicate copies. Defaults to False.
         """
         files_dir = Path(self.workflow_dir, "input-files", key)
 

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -35,7 +35,7 @@ class StreamlitUI:
         file_types: Union[str, List[str]],
         name: str = "",
         fallback: Union[List, str] = None,
-        symlink: bool = True
+        symlink: bool = True,
     ) -> None:
         """
         Handles file uploads through the Streamlit interface, supporting both direct
@@ -50,12 +50,14 @@ class StreamlitUI:
             symlink (bool, optional): Whether to symlink the uploaded files. This is used if local to avoid making duplicate copies. Defaults to True.
         """
         files_dir = Path(self.workflow_dir, "input-files", key)
-        
+
         # create the files dir
         files_dir.mkdir(exist_ok=True, parents=True)
 
         # check if only fallback files are in files_dir, if yes, reset the directory before adding new files
-        if [Path(f).name for f in Path(files_dir).iterdir()] == [Path(f).name for f in fallback]:
+        if [Path(f).name for f in Path(files_dir).iterdir()] == [
+            Path(f).name for f in fallback
+        ]:
             shutil.rmtree(files_dir)
             files_dir.mkdir()
 
@@ -87,9 +89,9 @@ class StreamlitUI:
                         files = [files]
                     for f in files:
                         # Check if file type is in the list of accepted file types
-                        if f.name not in [
-                            f.name for f in files_dir.iterdir()
-                        ] and any(f.name.endswith(ft) for ft in file_types):
+                        if f.name not in [f.name for f in files_dir.iterdir()] and any(
+                            f.name.endswith(ft) for ft in file_types
+                        ):
                             with open(Path(files_dir, f.name), "wb") as fh:
                                 fh.write(f.getbuffer())
                     st.success("Successfully added uploaded files!")
@@ -105,17 +107,17 @@ class StreamlitUI:
                     f"Copy **{name}** files from local folder", use_container_width=True
                 ):
                     files = []
-                    local_dir = Path(local_dir).expanduser()  # Expand ~ to full home directory path
+                    local_dir = Path(
+                        local_dir
+                    ).expanduser()  # Expand ~ to full home directory path
 
                     for ft in file_types:
-                        print(f"Searching for files with type: {ft} in {local_dir}")
                         # Search for both files and directories with the specified extension
                         for path in local_dir.iterdir():
                             if path.is_file() and path.name.endswith(f".{ft}"):
                                 files.append(path)
                             elif path.is_dir() and path.name.endswith(f".{ft}"):
                                 files.append(path)
-                        print(f"files: {files}")
 
                     if not files:
                         st.warning(
@@ -166,12 +168,14 @@ class StreamlitUI:
             ):
                 shutil.rmtree(files_dir)
                 del self.params[key]
-                with open(self.parameter_manager.params_file, "w", encoding="utf-8") as f:
+                with open(
+                    self.parameter_manager.params_file, "w", encoding="utf-8"
+                ) as f:
                     json.dump(self.params, f, indent=4)
                 st.rerun()
         elif not fallback:
             st.warning(f"No **{name}** files!")
-    
+
     def select_input_file(
         self,
         key: str,
@@ -420,7 +424,6 @@ class StreamlitUI:
                     if encoded_key in param.keys():
                         param.setValue(encoded_key, value)
                 poms.ParamXMLFile().store(str(ini_file_path), param)
-            
 
         # read into Param object
         param = poms.Param()
@@ -453,7 +456,7 @@ class StreamlitUI:
                 "section_description": param.getSectionDescription(':'.join(key.decode().split(':')[:-1]))
             }
             params_decoded.append(tmp)
-                    
+
         # for each parameter in params_decoded
         # if a parameter with custom default value exists, use that value
         # else check if the parameter is already in self.params, if yes take the value from self.params
@@ -471,7 +474,7 @@ class StreamlitUI:
         section_description = None
         cols = st.columns(num_cols)
         i = 0
-        
+
         for p in params_decoded:
             # skip avdanced parameters if not selected
             if not st.session_state["advanced"] and p["advanced"]:
@@ -479,11 +482,11 @@ class StreamlitUI:
 
             key = f"{self.parameter_manager.topp_param_prefix}{p['key'].decode()}"
             if display_subsections:
-                 name = p["name"]
-                 if section_description is None:
+                name = p["name"]
+                if section_description is None:
                     section_description = p['section_description']
-                    
-                 elif section_description != p['section_description']:
+
+                elif section_description != p['section_description']:
                     section_description = p['section_description']
                     st.markdown(f"**{section_description}**")
                     cols = st.columns(num_cols)
@@ -660,7 +663,7 @@ class StreamlitUI:
         Args:
             directory (str): The directory whose files are to be zipped.
         """
-       # Ensure directory is a Path object and check if directory is empty
+        # Ensure directory is a Path object and check if directory is empty
         directory = Path(directory)
         if not any(directory.iterdir()):
             st.error("No files to compress.")
@@ -697,8 +700,7 @@ class StreamlitUI:
             mime="application/zip",
             use_container_width=True
         )
-        
-        
+
     def file_upload_section(self, custom_upload_function) -> None:
         custom_upload_function()
         c1, _ = st.columns(2)

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -153,8 +153,6 @@ class StreamlitUI:
                                 # Write the path to the local directories to the file
                                 with open(external_files, "a") as f_handle:
                                     f_handle.write(f"{f}\n")
-                                    
-                                pass
                         my_bar.empty()
                         st.success("Successfully copied files!")
                         

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -52,6 +52,7 @@ class StreamlitUI:
             This function is not avaliable in a streamlit cloud context.
         """
         root = Tk()
+        root.attributes("-topmost", True)
         root.withdraw()
         file_path = filedialog.askdirectory(title=title, initialdir=parent_dir)
         root.destroy()

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -142,7 +142,7 @@ class StreamlitUI:
                             with open(external_files, "a") as f_handle:
                                 f_handle.write(f"{f}\n")
                         my_bar.empty()
-                        st.success("Successfully copied files!")
+                        st.success("Successfully added files!")
                         
                         st.session_state["previous_dir"] = Path(local_files[0]).parent
 

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -172,6 +172,15 @@ class StreamlitUI:
                                     shutil.copytree(f, Path(files_dir, f.name), dirs_exist_ok=True)
                             else:
                                 # Do we need to change the reference of Path(st.session_state.workspace, "mzML-files") to point to local dir? 
+                                # Create a temporary file to store the path to the local directories
+                                external_files = Path(files_dir, "external_files.txt")
+                                # Check if the file exists, if not create it
+                                if not external_files.exists():
+                                    external_files.touch()
+                                # Write the path to the local directories to the file
+                                with open(external_files, "a") as f_handle:
+                                    f_handle.write(f"{f}\n")
+                                    
                                 pass
                         my_bar.empty()
                         st.success("Successfully copied files!")

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -239,7 +239,8 @@ class StreamlitUI:
         if external_files.exists():
             with open(external_files, "r") as f:
                 external_files_list = f.read().splitlines()
-            options += external_files_list
+            # Only make files available that still exist
+            options += [f for f in external_files_list if os.path.exists(f)]
         if (key in self.params.keys()) and isinstance(self.params[key], list):
             self.params[key] = [f for f in self.params[key] if f in options]
 

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -145,7 +145,6 @@ class StreamlitUI:
                                 elif os.path.isdir(f):
                                     shutil.copytree(f, Path(files_dir, f.name), dirs_exist_ok=True)
                             else:
-                                # Do we need to change the reference of Path(st.session_state.workspace, "mzML-files") to point to local dir? 
                                 # Create a temporary file to store the path to the local directories
                                 external_files = Path(files_dir, "external_files.txt")
                                 # Check if the file exists, if not create it

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -135,15 +135,15 @@ class StreamlitUI:
                         file_types,
                         st.session_state["previous_dir"],
                     )
-                    st.write(local_files)
-                    my_bar = st.progress(0)
-                    for i, f in enumerate(local_files):
-                        with open(external_files, "a") as f_handle:
-                            f_handle.write(f"{f}\n")
-                    my_bar.empty()
-                    st.success("Successfully copied files!")
-                    
-                    st.session_state["previous_dir"] = Path(local_files[0]).parent
+                    if local_files:
+                        my_bar = st.progress(0)
+                        for i, f in enumerate(local_files):
+                            with open(external_files, "a") as f_handle:
+                                f_handle.write(f"{f}\n")
+                        my_bar.empty()
+                        st.success("Successfully copied files!")
+                        
+                        st.session_state["previous_dir"] = Path(local_files[0]).parent
 
         # Local file upload option: via directory path
         if st.session_state.location == "local":

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -260,7 +260,15 @@ class StreamlitUI:
         if not path.exists():
             st.warning(f"No **{name}** files!")
             return
-        options = [str(f) for f in path.iterdir()]
+        options = [str(f) for f in path.iterdir() if "external_files.txt" not in str(f)]
+        
+        # Check if local files are available
+        external_files = Path(self.workflow_dir, "input-files", key, "external_files.txt")
+        
+        if external_files.exists():
+            with open(external_files, "r") as f:
+                external_files_list = f.read().splitlines()
+            options += external_files_list
         if (key in self.params.keys()) and isinstance(self.params[key], list):
             self.params[key] = [f for f in self.params[key] if f in options]
 

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -151,8 +151,13 @@ class StreamlitUI:
                         my_bar.empty()
                         st.success("Successfully copied files!")
             if use_symlink:
-                c2.warning("**Warning**: You have selected to use symbolic links to the original files instead of making copies. This **_assumes you know what you are doing_**. If you are unsure, please uncheck the `Use symlinks` checkbox to use the safer copy option.")
-                
+                c2.warning(
+                    "**Warning**: You have selected to use symbolic links to the original files instead of making copies. "
+                    "This **_assumes you know what you are doing_**. Symbolic links point to the original files, "
+                    "meaning changes to the original will affect the links. If you are unsure, please uncheck the "
+                    "`Use symlinks` checkbox to use the safer copy option."
+                )
+
         if fallback and not any(Path(files_dir).iterdir()):
             if isinstance(fallback, str):
                 fallback = [fallback]

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -119,7 +119,7 @@ class StreamlitUI:
                     type="primary",
                     use_container_width=True,
                     key="local_browse_single",
-                    help="Browse for your local directory with MS data.",
+                    help="Browse for your local MS data files.",
                     disabled=not TK_AVAILABLE,
                 )
                 

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -183,7 +183,16 @@ class StreamlitUI:
             ]
         else:
             if files_dir.exists():
-                current_files = [f.name for f in files_dir.iterdir()]
+                current_files = [f.name for f in files_dir.iterdir() if "external_files.txt" not in f.name]
+                
+                # Check if local files are available
+                external_files = Path(self.workflow_dir, "input-files", key, "external_files.txt")
+                
+                if external_files.exists():
+                    with open(external_files, "r") as f:
+                        external_files_list = f.read().splitlines()
+                    # Only make files available that still exist
+                    current_files += [f"(local) {Path(f).name}" for f in external_files_list if os.path.exists(f)]            
             else:
                 current_files = []
 

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -125,10 +125,13 @@ class StreamlitUI:
                 )
                 
                 # Tk file dialog requires file types to be a list of tuples
-                if isinstance(file_types, list):
-                    tk_file_types = [(f"{ft}", f"*.{ft}") for ft in file_types]
                 if isinstance(file_types, str):
                     tk_file_types = [(f"{file_types}", f"*.{file_types}")]
+                elif isinstance(file_types, list):
+                    tk_file_types = [(f"{ft}", f"*.{ft}") for ft in file_types]
+                else:
+                    raise ValueError("'file_types' must be either of type str or list")
+                
                 
                 if dialog_button:
                     local_files = tk_file_dialog(

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -75,11 +75,12 @@ class StreamlitUI:
         else:
             use_copy = True
 
+        # Convert file_types to a list if it's a string
+        if isinstance(file_types, str):
+            file_types = [file_types]
+            
         if use_copy:
             with c1.form(f"{key}-upload", clear_on_submit=True):
-                # Convert file_types to a list if it's a string
-                if isinstance(file_types, str):
-                    file_types = [file_types]
                 # Streamlit file uploader accepts file types as a list or None
                 file_type_for_uploader = file_types if file_types else None
 
@@ -125,14 +126,14 @@ class StreamlitUI:
                 
                 # Tk file dialog requires file types to be a list of tuples
                 if isinstance(file_types, list):
-                    file_types = [(f"{ft}", f"*.{ft}") for ft in file_types]
+                    tk_file_types = [(f"{ft}", f"*.{ft}") for ft in file_types]
                 if isinstance(file_types, str):
-                    file_types = [(f"{file_types}", f"*.{file_types}")]
+                    tk_file_types = [(f"{file_types}", f"*.{file_types}")]
                 
                 if dialog_button:
                     local_files = tk_file_dialog(
                         "Select directory with your MS data",
-                        file_types,
+                        tk_file_types,
                         st.session_state["previous_dir"],
                     )
                     if local_files:

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -14,7 +14,7 @@ import zipfile
 from datetime import datetime
 
 
-from ..common import OS_PLATFORM, TK_AVAILABLE, tk_directory_dialog, tk_file_dialog
+from src.common import OS_PLATFORM, TK_AVAILABLE, tk_directory_dialog, tk_file_dialog
 
 class StreamlitUI:
     """

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -132,7 +132,7 @@ class StreamlitUI:
                 
                 if dialog_button:
                     local_files = tk_file_dialog(
-                        "Select directory with your MS data",
+                        "Select your local MS data files",
                         tk_file_types,
                         st.session_state["previous_dir"],
                     )

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -35,7 +35,7 @@ class StreamlitUI:
         file_types: Union[str, List[str]],
         name: str = "",
         fallback: Union[List, str] = None,
-        symlink: bool = True,
+        symlink: bool = False,
     ) -> None:
         """
         Handles file uploads through the Streamlit interface, supporting both direct

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -13,13 +13,8 @@ from io import BytesIO
 import zipfile
 from datetime import datetime
 
-try:
-    from tkinter import Tk, filedialog
-    TK_AVAILABLE = True
-except ImportError:
-    TK_AVAILABLE = False
-        
-from ..common import OS_PLATFORM
+
+from ..common import OS_PLATFORM, TK_AVAILABLE, tk_directory_dialog
 
 class StreamlitUI:
     """
@@ -36,27 +31,6 @@ class StreamlitUI:
         self.executor = executor
         self.parameter_manager = paramter_manager
         self.params = self.parameter_manager.get_parameters_from_json()
-
-    def tk_directory_dialog(self, title: str = "Select Directory", parent_dir: str = os.getcwd()):
-        """
-        Creates a Tkinter directory dialog for selecting a directory.
-
-        Args:
-            title (str): The title of the directory dialog.
-            parent_dir (str): The path to the parent directory of the directory dialog.
-
-        Returns:
-            str: The path to the selected directory.
-        
-        Warning:
-            This function is not avaliable in a streamlit cloud context.
-        """
-        root = Tk()
-        root.attributes("-topmost", True)
-        root.withdraw()
-        file_path = filedialog.askdirectory(title=title, initialdir=parent_dir)
-        root.destroy()
-        return file_path
 
     def upload_widget(
         self,
@@ -137,7 +111,7 @@ class StreamlitUI:
                     st.write("\n")
                     dialog_button = st.button("📁", key='local_browse', help="Browse for your local directory with MS data.", disabled=not TK_AVAILABLE)
                     if dialog_button:
-                        st.session_state["local_dir"] = self.tk_directory_dialog("Select directory with your MS data", st.session_state["previous_dir"])
+                        st.session_state["local_dir"] = tk_directory_dialog("Select directory with your MS data", st.session_state["previous_dir"])
                         st.session_state["previous_dir"] = st.session_state["local_dir"]
 
                 with st_cols[1]:

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -102,7 +102,7 @@ class StreamlitUI:
         # Local file upload option: via directory path
         if st.session_state.location == "local":
             c2_text, c2_checkbox = c2.columns([1.5, 1], gap="large")
-            c2_text.markdown("**OR copy files from local folder**")
+            c2_text.markdown("**OR add files from local folder**")
             use_copy = c2_checkbox.checkbox("Make a copy of files", key=f"{key}-copy_files", value=True, help="Create a copy of files in workspace.")
             with c2.container(border=True):
                 st_cols = st.columns([0.05, 0.55], gap="small")
@@ -117,7 +117,7 @@ class StreamlitUI:
                 with st_cols[1]:
                     local_dir = st.text_input(f"path to folder with **{name}** files", value=st.session_state["local_dir"])
                     
-                if c2.button(f"Copy **{name}** files from local folder", use_container_width=True):
+                if c2.button(f"Add **{name}** files from local folder", use_container_width=True):
                     files = []
                     local_dir = Path(
                         local_dir


### PR DESCRIPTION
### **User description**
I have been playing around with the streamlit-template to create a web-app for Sage. There were a few things I wanted to change with the file upload widget, more so specifically when running a web-app with local. If running a web-app with local, when uploading files, I personally prefer creating symbolic links to the original files (if the purpose is to just read data), to avoid making multiple copies. This I think is probably useful if there are a lot of files or large files that you want to process. I added an option to the file upload widget to create symlinks if requested (default) instead, otherwise make copies when running an app locally.

- Allow for file_types to be a list of str if user wants to upload more than one file type with the same upload widget
- Allow for uploading a directory, i.e. uploading a bruker .d file
- Allow for local symlink creation instead of copying/duplicating files

Let me know what you think.


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Enhanced the upload widget to support multiple file types by changing `file_type` to `file_types`.
- Added an option to create symlinks instead of copying files when running the app locally.
- Improved the handling of file uploads and local directory copying.
- Fixed formatting issues and removed debug print statements.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Workflow.py</strong><dd><code>Support multiple file types in upload widget</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Workflow.py

<li>Changed <code>file_type</code> to <code>file_types</code> to support multiple file types.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/streamlit-template/pull/75/files#diff-fdf1c9d830bb105576ddd0eac1c93b1ba44288dfa0c26fce49ddee4e8269349a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>StreamlitUI.py</strong><dd><code>Enhance upload widget with multiple file types and symlink option</code></dd></summary>
<hr>

src/workflow/StreamlitUI.py

<li>Added support for multiple file types in the upload widget.<br> <li> Added option to create symlinks instead of copying files.<br> <li> Improved handling of file uploads and local directory copying.<br> <li> Fixed formatting and removed debug print statements.<br>


</details>


  </td>
  <td><a href="https://github.com/OpenMS/streamlit-template/pull/75/files#diff-d2d8b6f64f15e9961120b170f519cff4a534717079fb0ab30a47afffa4a4daa7">+52/-28</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

