### PR TITLE
Fix Parameter Summary

### DIFF
--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -1055,8 +1055,6 @@ class StreamlitUI:
 
         for k, v in params.items():
             # skip if v is a file path
-            if Path(str(v)).exists():
-                continue
             if isinstance(v, dict):
                 topp[k] = v
             elif ".py" in k:


### PR DESCRIPTION
The parameter summary fails if too many files are selected at once. The reason is that all selected files are appended into a single string which then throws an error with `Path()` as it exceeds the maximum permissible file name length.

I found the deleted (and problematic) lines to be unnecessary as this is already covered by `remove_full_paths()`.