### PR TITLE
Adjust download file type

### DIFF
--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -8,6 +8,9 @@ on:
   
 env:
   OPENMS_VERSION: 3.2.0 
+  PYTHON_VERSION: 3.11.0
+  # Name of the installer
+  APP_NAME: OpenMS-StreamlitTemplateApp
   # Define needed TOPP tools here
   TOPP_TOOLS: "FeatureFinderMetabo FeatureLinkerUnlabeledKD SiriusExport"
 
@@ -172,11 +175,7 @@ jobs:
 
   build-executable:
     runs-on: windows-latest
-    needs: build-openms
-
-    env:
-      PYTHON_VERSION: 3.11.0
-      APP_NAME: OpenMS-StreamlitTemplateApp
+    needs: build-openms  
 
     steps:
     - name: Checkout

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -404,9 +404,13 @@ jobs:
       run: |
         ./wix/light.exe -ext WixUIExtension -sice:ICE60 -o ${{ env.APP_NAME }}.msi streamlit_exe_files.wixobj streamlit_exe.wixobj
 
+    - name: Compress Installer
+      run: |
+        7z a OpenMS-App.zip ${{ env.APP_NAME }}.msi
+
     - name: Archive build artifacts
       uses: actions/upload-artifact@v4
       with:
         name: OpenMS-App
         path: |
-          ${{ env.APP_NAME }}.msi
+          OpenMS-App.zip

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -54,7 +54,7 @@ jobs:
         # Install compatible versions of tools
         choco install ccache -y
         choco install ninja -y
-        choco install cmake --version=3.31.0 -y
+        choco install cmake --version=3.31.0 --allow-downgrade -y
         choco install cmake.install --version=3.31.0 --allow-downgrade -y
         
         echo "C:/Program Files (x86)/GitHub CLI" >> $GITHUB_PATH

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -45,18 +45,9 @@ jobs:
     - name: Setup build tools
       shell: bash
       run: |
-        #choco install ccache ninja cmake
+        choco install ccache ninja cmake
         ## GH CLI "SHOULD BE" installed. Sometimes I had to manually install nonetheless. Super weird.
         # https://github.com/actions/runner-images/blob/main/images/win/scripts/Installers/Install-GitHub-CLI.ps1
-        
-        # Update Chocolatey to the latest version
-        choco upgrade chocolatey -y
-        # Install compatible versions of tools
-        choco install ccache -y
-        choco install ninja -y
-        choco install cmake --version=3.31.0 --allow-downgrade -y
-        choco install cmake.install --version=3.31.0 --allow-downgrade -y
-        
         echo "C:/Program Files (x86)/GitHub CLI" >> $GITHUB_PATH
 
     - name: Extract branch/PR infos

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -55,7 +55,7 @@ jobs:
         choco install ccache -y
         choco install ninja -y
         choco install cmake --version=3.31.0 -y
-        choco install cmake.install --version=3.31.0 -y
+        choco install cmake.install --version=3.31.0 --allow-downgrade -y
         
         echo "C:/Program Files (x86)/GitHub CLI" >> $GITHUB_PATH
 

--- a/content/quickstart.py
+++ b/content/quickstart.py
@@ -43,23 +43,23 @@ c1.markdown(
 )
 v_space(1, c2)
 c2.image("assets/pyopenms_transparent_background.png", width=300)
-if Path("OpenMS-App.msi").exists():
+if Path("OpenMS-App.zip").exists():
     st.subheader(
         """
 Download the latest version for Windows here by clicking the button below.
 """
     )
-    with open("OpenMS-App.msi", "rb") as file:
+    with open("OpenMS-App.zip", "rb") as file:
         st.download_button(
             label="Download for Windows",
             data=file,
-            file_name="OpenMS-App.msi",
-            mime="application/x-ms-installer",
+            file_name="OpenMS-App.zip",
+            mime="archive/zip",
             type="primary",
         )
     st.markdown(
         """
-Run the installer (.msi) file to install the app. The app can then be launched using the corresponding desktop icon.
+Extract the zip file and run the installer (.msi) file to install the app. The app can then be launched using the corresponding desktop icon.
 """
     )
 

--- a/content/quickstart.py
+++ b/content/quickstart.py
@@ -43,23 +43,23 @@ c1.markdown(
 )
 v_space(1, c2)
 c2.image("assets/pyopenms_transparent_background.png", width=300)
-if Path("OpenMS-App.zip").exists():
+if Path("OpenMS-App.msi").exists():
     st.subheader(
         """
 Download the latest version for Windows here by clicking the button below.
 """
     )
-    with open("OpenMS-App.zip", "rb") as file:
+    with open("OpenMS-App.msi", "rb") as file:
         st.download_button(
             label="Download for Windows",
             data=file,
-            file_name="OpenMS-App.zip",
-            mime="archive/zip",
+            file_name="OpenMS-App.msi",
+            mime="application/x-ms-installer",
             type="primary",
         )
     st.markdown(
         """
-Extract the zip file and run the executable (.exe) file to launch the app. Since every dependency is compressed and packacked the app will take a while to launch (up to one minute).
+Run the installer (.msi) file to install the app. The app can then be launched using the corresponding desktop icon.
 """
     )
 


### PR DESCRIPTION
The new `.msi` installer is not detected by the tempalte as it looking  for a zip file. This PR adjusts the download for windows to the new file type.