### PR TITLE
fix revert to default values

### DIFF
--- a/src/workflow/ParameterManager.py
+++ b/src/workflow/ParameterManager.py
@@ -67,7 +67,10 @@ class ParameterManager:
                     # get ini (default) value by ini_key
                     ini_value = param.getValue(ini_key)
                     # check if value is different from default
-                    if ini_value != value:
+                    if (
+                        (ini_value != value) 
+                        or (key.split(":1:")[1] in json_params[tool])
+                    ):
                         # store non-default value
                         json_params[tool][key.split(":1:")[1]] = value
         # Save to json file


### PR DESCRIPTION
This PR fixes the following bug:

If a TOPP parameter was set to a non-default value and is then set back to a default value, the changes are not written to the `params.json`.