### PR TITLE
add better storage solution

### DIFF
--- a/src/workflow/WorkflowManager.py
+++ b/src/workflow/WorkflowManager.py
@@ -11,10 +11,16 @@ import time
 
 class WorkflowManager:
     # Core workflow logic using the above classes
-    def __init__(self, name: str, workspace: str):
+    def __init__(self, name: str, workspace: str, share_cache: bool = False):
         self.name = name
         self.workflow_dir = Path(workspace, name.replace(" ", "-").lower())
-        self.file_manager = FileManager(self.workflow_dir)
+
+        if share_cache:
+            cache_path = Path(workspace, 'cache')
+        else:
+            cache_path = Path(self.workflow_dir, 'cache')
+        
+        self.file_manager = FileManager(self.workflow_dir, cache_path)
         self.logger = Logger(self.workflow_dir)
         self.parameter_manager = ParameterManager(self.workflow_dir)
         self.executor = CommandExecutor(self.workflow_dir, self.logger, self.parameter_manager)


### PR DESCRIPTION
This PR adds a caching solution to the template. Files/Data can be stored using a simple interface (`store_file`/`store_data`). Cached data is written to disk and kept track of using a `sqlite3` database. Files are stored in a central location and their path is stored as a reference. Python objects are pickled and gzipped, with the exception of dataframes, which are written to parquet.

ToDos:
- [ ] Complete Documentation
- [ ] Check if the complete file manager can be moved to this solution without breaking backwards compatibility