### PR TITLE
allow downgrades for ci

### DIFF
--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -46,7 +46,7 @@ jobs:
       shell: bash
       run: |
         choco install ccache ninja -y --no-progress
-        choco install cmake --version=3.31.1 -y --no-progress
+        choco install cmake --version=3.31.1 -y --no-progress --force
         ## GH CLI "SHOULD BE" installed. Sometimes I had to manually install nonetheless. Super weird.
         # https://github.com/actions/runner-images/blob/main/images/win/scripts/Installers/Install-GitHub-CLI.ps1
         echo "C:/Program Files (x86)/GitHub CLI" >> $GITHUB_PATH


### PR DESCRIPTION
For some runners, a newer version of cmake is already installed, causing the installation to fail and thus the error to reappear. This PR forces the installation.