### PR TITLE
Add annotations for List inputs

### DIFF
--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -755,10 +755,17 @@ class StreamlitUI:
                             v.decode() if isinstance(v, bytes) else v
                             for v in p["value"]
                         ]
+                        valid_entries_info = ''
+                        if len(p['valid_strings']) > 0:
+                            valid_entries_info = (
+                                " Valid entries are: "
+                                + ', '.join(sorted(p['valid_strings']))
+                            )
+
                         cols[i].text_area(
                             name,
                             value="\n".join([str(val) for val in p["value"]]),
-                            help=p["description"],
+                            help=p["description"] + " Separate entries using the \"Enter\" key." + valid_entries_info,
                             key=key,
                         )
 


### PR DESCRIPTION
If a TOPP tool requires a list input, items in the list should be separated by newline characters. This PR adds a message informing the user to press the enter key to separate values.

Furthermore, if the list has a controlled vocabulary, valid values are also displayed in the info tooltip.