### PR TITLE
Add Docker Compose as Deployment Option

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+
+services:
+  openms-streamlit-template:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        GITHUB_TOKEN: $GITHUB_TOKEN
+    image: openms_streamlit_template
+    container_name: openms-streamlit-template
+    restart: always
+    ports:
+      - 8501:8501
+    volumes:
+      - workspaces-streamlit-template:/workspaces-streamlit-template
+    command: streamlit run openms-streamlit-template/app.py
+volumes:
+  workspaces-streamlit-template:


### PR DESCRIPTION
This PR adds docker compose as deployment option. While deployment of single apps is in theory possible using `docker`, it requires quite some user configuration to work properly. For instance, the port and volume have to be specified manually. `docker-compose`  ensures that the configuration is reproducible and more user friendly.