### PR TITLE
Allow Large Amount of files

### DIFF
--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -321,9 +321,7 @@ jobs:
         <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
           <Product Id="*" Name="${{ env.APP_NAME }}" Language="1033" Version="1.0.0.0" Codepage="1252" Manufacturer="OpenMS Developer Team" UpgradeCode="${{ env.APP_UpgradeCode }}">
             <Package Id="*" InstallerVersion="300" Compressed="yes" InstallPrivileges="elevated" Platform="x64" />
-            <Media Id="1" Cabinet="strm1.cab" EmbedCab="yes" />
-            <Media Id="2" Cabinet="strm2.cab" EmbedCab="yes" />
-            <Media Id="3" Cabinet="strm3.cab" EmbedCab="yes" />
+            <MediaTemplate EmbedCab="yes" />
         
             <!-- Folder structure -->
             <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -321,7 +321,9 @@ jobs:
         <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
           <Product Id="*" Name="${{ env.APP_NAME }}" Language="1033" Version="1.0.0.0" Codepage="1252" Manufacturer="OpenMS Developer Team" UpgradeCode="${{ env.APP_UpgradeCode }}">
             <Package Id="*" InstallerVersion="300" Compressed="yes" InstallPrivileges="elevated" Platform="x64" />
-            <Media Id="1" Cabinet="streamlit.cab" EmbedCab="yes" />
+            <Media Id="1" Cabinet="streamlit1.cab" DiskId="1" MaxCabinetSize="200000000" />
+            <Media Id="2" Cabinet="streamlit2.cab" DiskId="2" />
+            <Media Id="3" Cabinet="streamlit3.cab" DiskId="3" />
         
             <!-- Folder structure -->
             <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
@@ -396,7 +398,7 @@ jobs:
         
     - name: Link .wixobj file into .msi with light.exe
       run: |
-        ./wix/light.exe -ext WixUIExtension -sice:ICE60 -o ${{ env.APP_NAME }}.msi streamlit_exe_files.wixobj streamlit_exe.wixobj
+        ./wix/light.exe -ext WixUIExtension -sice:ICE60 -o ${{ env.APP_NAME }}.msi streamlit_exe_files.wixobj streamlit_exe.wixobj -b SourceDir
 
     - name: Compress Installer
       run: |

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -321,9 +321,9 @@ jobs:
         <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
           <Product Id="*" Name="${{ env.APP_NAME }}" Language="1033" Version="1.0.0.0" Codepage="1252" Manufacturer="OpenMS Developer Team" UpgradeCode="${{ env.APP_UpgradeCode }}">
             <Package Id="*" InstallerVersion="300" Compressed="yes" InstallPrivileges="elevated" Platform="x64" />
-            <Media Id="1" Cabinet="streamlit1.cab" DiskId="1" MaxCabinetSize="200000000" />
-            <Media Id="2" Cabinet="streamlit2.cab" DiskId="2" />
-            <Media Id="3" Cabinet="streamlit3.cab" DiskId="3" />
+            <Media Id="1" Cabinet="strm1.cab" EmbedCab="yes" />
+            <Media Id="2" Cabinet="strm2.cab" EmbedCab="yes" />
+            <Media Id="3" Cabinet="strm3.cab" EmbedCab="yes" />
         
             <!-- Folder structure -->
             <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />

--- a/.github/workflows/test-win-exe-w-embed-py.yaml
+++ b/.github/workflows/test-win-exe-w-embed-py.yaml
@@ -2,6 +2,8 @@ name: Test streamlit executable for Windows with embeddable python
 on: 
   push:
     branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
   workflow_dispatch:
 
 jobs:
@@ -118,7 +120,7 @@ jobs:
           <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
             <Product Id="*" Name="${{ env.APP_NAME }}" Language="1033" Version="1.0.0.0" Codepage="1252" Manufacturer="OpenMS Developer Team" UpgradeCode="${{ env.APP_UpgradeCode }}">
               <Package Id="*" InstallerVersion="300" Compressed="yes" InstallPrivileges="elevated" Platform="x64" />
-              <Media Id="1" Cabinet="streamlit.cab" EmbedCab="yes" />
+              <MediaTemplate EmbedCab="yes" />
           
               <!-- Folder structure -->
               <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
@@ -193,7 +195,7 @@ jobs:
           
       - name: Link .wixobj file into .msi with light.exe
         run: |
-          ./wix/light.exe -ext WixUIExtension -sice:ICE60 -o ${{ env.APP_NAME }}.msi streamlit_exe_files.wixobj streamlit_exe.wixobj
+          ./wix/light.exe -ext WixUIExtension -sice:ICE60 -o ${{ env.APP_NAME }}.msi streamlit_exe_files.wixobj streamlit_exe.wixobj -b SourceDir
 
       - name: Archive build artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
When adding additional dependencies in umetaflow, the file count limit of the `streamlit.cab` file was exceeded. This PR ensures that files are automatically distributed across multiple `.cab` files if necessary.

I also enabled the `test-win-exe-w-embed-py` GA on PR to main. However, from what I saw it does not seem to test anything. @Arslan-Siraj can this be removed?