### PR TITLE
Drop spectra without peaks in data viewer

### DIFF
--- a/src/view.py
+++ b/src/view.py
@@ -35,6 +35,10 @@ def get_df(file: Union[str, Path]) -> pd.DataFrame:
         else:
             precs.append(np.nan)
     df_spectra["precursor m/z"] = precs
+
+    # Drop spectra without peaks
+    df_spectra = df_spectra[df_spectra["mzarray"].apply(lambda x: len(x) > 0)]
+
     df_spectra["max intensity m/z"] = df_spectra.apply(
         lambda x: x["mzarray"][x["intarray"].argmax()], axis=1
     )


### PR DESCRIPTION
Addresses issue raised on Discord. Error confirmed with an mzML file containing empty spectra. Here, they are simply dropped to avoid any downstream issues.