### PR TITLE
Add workspace management features and disable workspace setting

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -12,5 +12,6 @@
             "tag": "57690c44-d635-43b0-ab43-f8bd3064ca06"
         }
     },
-    "online_deployment": false
+    "online_deployment": false,
+    "is_workspace_enabled": true
 }

--- a/settings.json
+++ b/settings.json
@@ -13,5 +13,5 @@
         }
     },
     "online_deployment": false,
-    "is_workspace_enabled": true
+    "enable_workspaces": true
 }

--- a/src/common/common.py
+++ b/src/common/common.py
@@ -41,6 +41,11 @@ def load_params(default: bool = False) -> dict[str, Any]:
     Returns:
         dict[str, Any]: A dictionary containing the parameters.
     """
+    
+    # Check if workspace is enabled. If not, load default parameters.
+    if not st.session_state.settings["is_workspace_enabled"] == True:
+        default = True
+    
     # Construct the path to the parameter file
     path = Path(st.session_state.workspace, "params.json")
 
@@ -75,6 +80,11 @@ def save_params(params: dict[str, Any]) -> None:
     Returns:
         dict[str, Any]: Updated parameters.
     """
+    
+    # Check if the workspace is enabled and if a 'params.json' file exists in the workspace directory
+    if not st.session_state.settings["is_workspace_enabled"] == True:
+        return
+    
     # Update the parameter dictionary with any modified parameters from the current session
     for key, value in st.session_state.items():
         if key in params.keys():
@@ -199,21 +209,27 @@ def page_setup(page: str = "") -> dict[str, Any]:
             os.chdir("../streamlit-template")
         # Define the directory where all workspaces will be stored
         workspaces_dir = Path("..", "workspaces-" + st.session_state.settings["repository-name"])
-        if "workspace" in st.query_params:
-            st.session_state.workspace = Path(workspaces_dir, st.query_params.workspace)
-        elif st.session_state.location == "online":
-            workspace_id = str(uuid.uuid1())
-            st.session_state.workspace = Path(workspaces_dir, workspace_id)
-            st.query_params.workspace = workspace_id
+        # Check if workspace logic exist if it is keep existing logic or set the default workspace but without params
+        if st.session_state.settings["is_workspace_enabled"] == True:
+            if "workspace" in st.query_params:
+                    st.session_state.workspace = Path(workspaces_dir, st.query_params.workspace)
+            elif st.session_state.location == "online":
+                    workspace_id = str(uuid.uuid1())
+                    st.session_state.workspace = Path(workspaces_dir, workspace_id)
+                    st.query_params.workspace = workspace_id
+            else:
+                st.session_state.workspace = Path(workspaces_dir, "default")
+                st.query_params.workspace = "default"
+                
         else:
             st.session_state.workspace = Path(workspaces_dir, "default")
-            st.query_params.workspace = "default"
 
         if st.session_state.location != "online":
             # not any captcha so, controllo should be true
             st.session_state["controllo"] = True
 
-    if "workspace" not in st.query_params:
+    # If no workspace is specified and workspace feature is enabled, set default workspace and query param
+    if "workspace" not in st.query_params and st.session_state.settings["is_workspace_enabled"] == True:
         st.query_params.workspace = st.session_state.workspace.name
 
     # Make sure the necessary directories exist
@@ -248,51 +264,53 @@ def render_sidebar(page: str = "") -> None:
     params = load_params()
     with st.sidebar:
         # The main page has workspace switcher
-        with st.expander("🖥️ **Workspaces**"):
-            # Define workspaces directory outside of repository
-            workspaces_dir = Path("..", "workspaces-" + st.session_state.settings["repository-name"])
-            # Online: show current workspace name in info text and option to change to other existing workspace
-            if st.session_state.location == "local":
-                # Define callback function to change workspace
-                def change_workspace():
-                    for key in params.keys():
-                        if key in st.session_state.keys():
-                            del st.session_state[key]
-                    st.session_state.workspace = Path(
-                        workspaces_dir, st.session_state["chosen-workspace"]
-                    )
-                    st.query_params.workspace = st.session_state["chosen-workspace"]
+        # Display workspace switcher if workspace is enabled in local mode
+        if st.session_state.settings["is_workspace_enabled"]:
+            with st.expander("🖥️ **Workspaces**"):
+                # Define workspaces directory outside of repository
+                workspaces_dir = Path("..", "workspaces-" + st.session_state.settings["repository-name"])
+                # Online: show current workspace name in info text and option to change to other existing workspace
+                if st.session_state.location == "local":
+                    # Define callback function to change workspace
+                    def change_workspace():
+                        for key in params.keys():
+                            if key in st.session_state.keys():
+                                del st.session_state[key]
+                        st.session_state.workspace = Path(
+                            workspaces_dir, st.session_state["chosen-workspace"]
+                        )
+                        st.query_params.workspace = st.session_state["chosen-workspace"]
 
-                # Get all available workspaces as options
-                options = [
-                    file.name for file in workspaces_dir.iterdir() if file.is_dir()
-                ]
-                # Let user chose an already existing workspace
-                st.selectbox(
-                    "choose existing workspace",
-                    options,
-                    index=options.index(str(st.session_state.workspace.stem)),
-                    on_change=change_workspace,
-                    key="chosen-workspace",
-                )
-                # Create or Remove workspaces
-                create_remove = st.text_input("create/remove workspace", "")
-                path = Path(workspaces_dir, create_remove)
-                # Create new workspace
-                if st.button("**Create Workspace**"):
-                    path.mkdir(parents=True, exist_ok=True)
-                    st.session_state.workspace = path
-                    st.query_params.workspace = create_remove
-                    # Temporary as the query update takes a short amount of time
-                    time.sleep(1)
-                    st.rerun()
-                # Remove existing workspace and fall back to default
-                if st.button("⚠️ Delete Workspace"):
-                    if path.exists():
-                        shutil.rmtree(path)
-                        st.session_state.workspace = Path(workspaces_dir, "default")
-                        st.query_params.workspace = "default"
+                    # Get all available workspaces as options
+                    options = [
+                        file.name for file in workspaces_dir.iterdir() if file.is_dir()
+                    ]
+                    # Let user chose an already existing workspace
+                    st.selectbox(
+                        "choose existing workspace",
+                        options,
+                        index=options.index(str(st.session_state.workspace.stem)),
+                        on_change=change_workspace,
+                        key="chosen-workspace",
+                    )
+                    # Create or Remove workspaces
+                    create_remove = st.text_input("create/remove workspace", "")
+                    path = Path(workspaces_dir, create_remove)
+                    # Create new workspace
+                    if st.button("**Create Workspace**"):
+                        path.mkdir(parents=True, exist_ok=True)
+                        st.session_state.workspace = path
+                        st.query_params.workspace = create_remove
+                        # Temporary as the query update takes a short amount of time
+                        time.sleep(1)
                         st.rerun()
+                    # Remove existing workspace and fall back to default
+                    if st.button("⚠️ Delete Workspace"):
+                        if path.exists():
+                            shutil.rmtree(path)
+                            st.session_state.workspace = Path(workspaces_dir, "default")
+                            st.query_params.workspace = "default"
+                            st.rerun()
 
         # All pages have settings, workflow indicator and logo
         with st.expander("⚙️ **Settings**"):

--- a/src/common/common.py
+++ b/src/common/common.py
@@ -43,7 +43,7 @@ def load_params(default: bool = False) -> dict[str, Any]:
     """
     
     # Check if workspace is enabled. If not, load default parameters.
-    if not st.session_state.settings["is_workspace_enabled"] == True:
+    if not st.session_state.settings["is_workspace_enabled"]:
         default = True
     
     # Construct the path to the parameter file
@@ -82,7 +82,7 @@ def save_params(params: dict[str, Any]) -> None:
     """
     
     # Check if the workspace is enabled and if a 'params.json' file exists in the workspace directory
-    if not st.session_state.settings["is_workspace_enabled"] == True:
+    if not st.session_state.settings["is_workspace_enabled"]:
         return
     
     # Update the parameter dictionary with any modified parameters from the current session
@@ -209,8 +209,8 @@ def page_setup(page: str = "") -> dict[str, Any]:
             os.chdir("../streamlit-template")
         # Define the directory where all workspaces will be stored
         workspaces_dir = Path("..", "workspaces-" + st.session_state.settings["repository-name"])
-        # Check if workspace logic exist if it is keep existing logic or set the default workspace but without params
-        if st.session_state.settings["is_workspace_enabled"] == True:
+        # Check if workspace logic is enabled
+        if st.session_state.settings["is_workspace_enabled"]:
             if "workspace" in st.query_params:
                     st.session_state.workspace = Path(workspaces_dir, st.query_params.workspace)
             elif st.session_state.location == "online":
@@ -222,6 +222,7 @@ def page_setup(page: str = "") -> dict[str, Any]:
                 st.query_params.workspace = "default"
                 
         else:
+            # Use default workspace when workspace feature is disabled
             st.session_state.workspace = Path(workspaces_dir, "default")
 
         if st.session_state.location != "online":
@@ -229,7 +230,7 @@ def page_setup(page: str = "") -> dict[str, Any]:
             st.session_state["controllo"] = True
 
     # If no workspace is specified and workspace feature is enabled, set default workspace and query param
-    if "workspace" not in st.query_params and st.session_state.settings["is_workspace_enabled"] == True:
+    if "workspace" not in st.query_params and st.session_state.settings["is_workspace_enabled"]:
         st.query_params.workspace = st.session_state.workspace.name
 
     # Make sure the necessary directories exist

--- a/src/common/common.py
+++ b/src/common/common.py
@@ -43,7 +43,7 @@ def load_params(default: bool = False) -> dict[str, Any]:
     """
     
     # Check if workspace is enabled. If not, load default parameters.
-    if not st.session_state.settings["is_workspace_enabled"]:
+    if not st.session_state.settings["enable_workspaces"]:
         default = True
     
     # Construct the path to the parameter file
@@ -82,7 +82,7 @@ def save_params(params: dict[str, Any]) -> None:
     """
     
     # Check if the workspace is enabled and if a 'params.json' file exists in the workspace directory
-    if not st.session_state.settings["is_workspace_enabled"]:
+    if not st.session_state.settings["enable_workspaces"]:
         return
     
     # Update the parameter dictionary with any modified parameters from the current session
@@ -210,7 +210,7 @@ def page_setup(page: str = "") -> dict[str, Any]:
         # Define the directory where all workspaces will be stored
         workspaces_dir = Path("..", "workspaces-" + st.session_state.settings["repository-name"])
         # Check if workspace logic is enabled
-        if st.session_state.settings["is_workspace_enabled"]:
+        if st.session_state.settings["enable_workspaces"]:
             if "workspace" in st.query_params:
                     st.session_state.workspace = Path(workspaces_dir, st.query_params.workspace)
             elif st.session_state.location == "online":
@@ -230,7 +230,7 @@ def page_setup(page: str = "") -> dict[str, Any]:
             st.session_state["controllo"] = True
 
     # If no workspace is specified and workspace feature is enabled, set default workspace and query param
-    if "workspace" not in st.query_params and st.session_state.settings["is_workspace_enabled"]:
+    if "workspace" not in st.query_params and st.session_state.settings["enable_workspaces"]:
         st.query_params.workspace = st.session_state.workspace.name
 
     # Make sure the necessary directories exist
@@ -266,7 +266,7 @@ def render_sidebar(page: str = "") -> None:
     with st.sidebar:
         # The main page has workspace switcher
         # Display workspace switcher if workspace is enabled in local mode
-        if st.session_state.settings["is_workspace_enabled"]:
+        if st.session_state.settings["enable_workspaces"]:
             with st.expander("🖥️ **Workspaces**"):
                 # Define workspaces directory outside of repository
                 workspaces_dir = Path("..", "workspaces-" + st.session_state.settings["repository-name"])


### PR DESCRIPTION
updated the `settings.json`
 file to include a new key use_workspace_logic with a default value of true. This setting controls whether to use the existing workspace logic or not.

updated `src/common/common.py` to handle the single workspace scenario when is_workspace_enabled  is false. This includes loading default parameters if no other parameters are found and saving changes to a JSON file in the workspace directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled workspace functionality through updated configuration settings.
  - Enhanced user experience with dynamic workspace management, including intuitive default behaviors and conditional display of workspace controls.
  - Introduced a new configuration option: `"enable_workspaces": true` in settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->