### PR TITLE
Added installer as a release asset #139

### DIFF
--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -4,6 +4,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  release:
+    types: [created]
   workflow_dispatch:
   
 env:
@@ -174,6 +176,14 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+
+    - name: Set Version in settings.json
+      run: |
+        $VERSION="${{ github.event.release.tag_name }}"
+        $content = Get-Content -Raw settings.json | ConvertFrom-Json
+        $content.version = $VERSION
+        $content | ConvertTo-Json -Depth 100 | Set-Content settings.json
+
 
     - name: Download package as artifact
       uses: actions/download-artifact@v4

--- a/Dockerfile_simple
+++ b/Dockerfile_simple
@@ -94,16 +94,18 @@ RUN chmod +x /app/entrypoint.sh
 # Patch Analytics
 RUN mamba run -n streamlit-env python hooks/hook-analytics.py
 
-# Set Online Deployment
-RUN jq '.online_deployment = true' settings.json > tmp.json && mv tmp.json settings.json
+# Set Online Deployment and Version
+RUN LATEST_RELEASE=$(curl -s https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/latest | jq -r '.tag_name') && \
+    jq --arg version "$LATEST_RELEASE" '.online_deployment = true | .version = $version' settings.json > tmp.json && mv tmp.json settings.json
 
-# Download latest OpenMS App executable for Windows from Github actions workflow.
-RUN if [ -n "$GH_TOKEN" ]; then \
-        echo "GH_TOKEN is set, proceeding to download the release asset..."; \
-        gh run download -R ${GITHUB_USER}/${GITHUB_REPO} $(gh run list -R ${GITHUB_USER}/${GITHUB_REPO} -b main -e push -s completed -w "Build executable for Windows" --json databaseId -q '.[0].databaseId') -n OpenMS-App --dir /app; \
-    else \
-        echo "GH_TOKEN is not set, skipping the release asset download."; \
-    fi
+
+# Download latest OpenMS App installer from GitHub Releases
+RUN LATEST_RELEASE=$(curl -s https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/latest | jq -r '.tag_name') && \
+    DOWNLOAD_URL=$(curl -s https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/latest | \
+    jq -r '.assets[] | select(.name | endswith("OpenMS-App.zip")) | .browser_download_url') && \
+    wget -O /app/OpenMS-App.zip $DOWNLOAD_URL && \
+    unzip /app/OpenMS-App.zip -d /app/OpenMS-App && \
+    rm /app/OpenMS-App.zip
 
 # make sure that mamba environment is used
 SHELL ["mamba", "run", "-n", "streamlit-env", "/bin/bash", "-c"]

--- a/Dockerfile_simple
+++ b/Dockerfile_simple
@@ -100,9 +100,13 @@ RUN LATEST_RELEASE=$(curl -s https://api.github.com/repos/${GITHUB_USER}/${GITHU
 
 
 # Download latest OpenMS App installer from GitHub Releases
-RUN LATEST_RELEASE=$(curl -s https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/latest | jq -r '.tag_name') && \
-    DOWNLOAD_URL=$(curl -s https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/latest | \
-    jq -r '.assets[] | select(.name | endswith("OpenMS-App.zip")) | .browser_download_url') && \
+RUN LATEST_RELEASE=$([ -f /etc/environment ] && source /etc/environment && echo $LATEST_RELEASE || curl -s https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/latest | jq -r '.tag_name') && \
+    RESPONSE=$(curl -s https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/latest) && \
+    DOWNLOAD_URL=$(echo $RESPONSE | jq -r '.assets[] | select(.name | endswith("OpenMS-App.zip")) | .browser_download_url') && \
+    if [ -z "$DOWNLOAD_URL" ]; then \
+        echo "Error: Could not find OpenMS-App.zip in the latest release assets" && \
+        exit 1; \
+    fi && \
     wget -O /app/OpenMS-App.zip $DOWNLOAD_URL && \
     unzip /app/OpenMS-App.zip -d /app/OpenMS-App && \
     rm /app/OpenMS-App.zip

--- a/settings.json
+++ b/settings.json
@@ -12,5 +12,6 @@
             "tag": "57690c44-d635-43b0-ab43-f8bd3064ca06"
         }
     },
-    "online_deployment": false
+    "online_deployment": false,
+    "version": "0.0.0"
 }


### PR DESCRIPTION
Here, I have include the version updates..
When a new release is created the github action build-windows-executable-app.yaml is running and the resulting installer should be uploaded as release asset.
Docker files are using latest release asset..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automated version tracking now updates deployment settings with the latest release information.
  - The installer download process has been enhanced to always fetch the most recent release.

- **Chores**
  - Improvements to the build and deployment pipeline ensure configuration settings are updated accurately and deployment processes are streamlined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->