### PR TITLE
Add installer to release asset issue #139

### DIFF
--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -4,6 +4,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  release:
+    types: [created]
   workflow_dispatch:
   
 env:
@@ -174,6 +176,14 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+
+    - name: Set Version in settings.json
+      run: |
+        $VERSION="${{ github.event.release.tag_name }}"
+        $content = Get-Content -Raw settings.json | ConvertFrom-Json
+        $content.version = $VERSION
+        $content | ConvertTo-Json -Depth 100 | Set-Content settings.json
+
 
     - name: Download package as artifact
       uses: actions/download-artifact@v4

--- a/Dockerfile_simple
+++ b/Dockerfile_simple
@@ -94,16 +94,18 @@ RUN chmod +x /app/entrypoint.sh
 # Patch Analytics
 RUN mamba run -n streamlit-env python hooks/hook-analytics.py
 
-# Set Online Deployment
-RUN jq '.online_deployment = true' settings.json > tmp.json && mv tmp.json settings.json
+# Set Online Deployment and Version
+RUN LATEST_RELEASE=$(curl -s https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/latest | jq -r '.tag_name') && \
+    jq --arg version "$LATEST_RELEASE" '.online_deployment = true | .version = $version' settings.json > tmp.json && mv tmp.json settings.json
 
-# Download latest OpenMS App executable for Windows from Github actions workflow.
-RUN if [ -n "$GH_TOKEN" ]; then \
-        echo "GH_TOKEN is set, proceeding to download the release asset..."; \
-        gh run download -R ${GITHUB_USER}/${GITHUB_REPO} $(gh run list -R ${GITHUB_USER}/${GITHUB_REPO} -b main -e push -s completed -w "Build executable for Windows" --json databaseId -q '.[0].databaseId') -n OpenMS-App --dir /app; \
-    else \
-        echo "GH_TOKEN is not set, skipping the release asset download."; \
-    fi
+
+# Download latest OpenMS App installer from GitHub Releases
+RUN LATEST_RELEASE=$(curl -s https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/latest | jq -r '.tag_name') && \
+    DOWNLOAD_URL=$(curl -s https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/latest | \
+    jq -r '.assets[] | select(.name | endswith("OpenMS-App.zip")) | .browser_download_url') && \
+    wget -O /app/OpenMS-App.zip $DOWNLOAD_URL && \
+    unzip /app/OpenMS-App.zip -d /app/OpenMS-App && \
+    rm /app/OpenMS-App.zip
 
 # make sure that mamba environment is used
 SHELL ["mamba", "run", "-n", "streamlit-env", "/bin/bash", "-c"]

--- a/Dockerfile_simple
+++ b/Dockerfile_simple
@@ -94,7 +94,7 @@ RUN chmod +x /app/entrypoint.sh
 # Patch Analytics
 RUN mamba run -n streamlit-env python hooks/hook-analytics.py
 
-# Set Online Deployment and Version
+# Set Online Deployment
 RUN jq '.online_deployment = true' settings.json > tmp.json && mv tmp.json settings.json
 
 # Download latest OpenMS App executable for Windows from GitHub Releases

--- a/Dockerfile_simple
+++ b/Dockerfile_simple
@@ -100,9 +100,13 @@ RUN LATEST_RELEASE=$(curl -s https://api.github.com/repos/${GITHUB_USER}/${GITHU
 
 
 # Download latest OpenMS App installer from GitHub Releases
-RUN LATEST_RELEASE=$(curl -s https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/latest | jq -r '.tag_name') && \
-    DOWNLOAD_URL=$(curl -s https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/latest | \
-    jq -r '.assets[] | select(.name | endswith("OpenMS-App.zip")) | .browser_download_url') && \
+RUN LATEST_RELEASE=$([ -f /etc/environment ] && source /etc/environment && echo $LATEST_RELEASE || curl -s https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/latest | jq -r '.tag_name') && \
+    RESPONSE=$(curl -s https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/latest) && \
+    DOWNLOAD_URL=$(echo $RESPONSE | jq -r '.assets[] | select(.name | endswith("OpenMS-App.zip")) | .browser_download_url') && \
+    if [ -z "$DOWNLOAD_URL" ]; then \
+        echo "Error: Could not find OpenMS-App.zip in the latest release assets" && \
+        exit 1; \
+    fi && \
     wget -O /app/OpenMS-App.zip $DOWNLOAD_URL && \
     unzip /app/OpenMS-App.zip -d /app/OpenMS-App && \
     rm /app/OpenMS-App.zip

--- a/Dockerfile_simple
+++ b/Dockerfile_simple
@@ -95,21 +95,18 @@ RUN chmod +x /app/entrypoint.sh
 RUN mamba run -n streamlit-env python hooks/hook-analytics.py
 
 # Set Online Deployment and Version
-RUN LATEST_RELEASE=$(curl -s https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/latest | jq -r '.tag_name') && \
-    jq --arg version "$LATEST_RELEASE" '.online_deployment = true | .version = $version' settings.json > tmp.json && mv tmp.json settings.json
+RUN jq '.online_deployment = true' settings.json > tmp.json && mv tmp.json settings.json
 
+# Download latest OpenMS App executable for Windows from GitHub Releases
+RUN if [ -n "$GH_TOKEN" ]; then \
+        echo "GH_TOKEN is set, proceeding to download the release asset..."; \
+        gh release download -R ${GITHUB_USER}/${GITHUB_REPO} -p "OpenMS-App.zip" -D /app; \
+        unzip /app/OpenMS-App.zip -d /app/OpenMS-App && \
+        rm /app/OpenMS-App.zip; \
+    else \
+        echo "GH_TOKEN is not set, skipping the release asset download."; \
+    fi
 
-# Download latest OpenMS App installer from GitHub Releases
-RUN LATEST_RELEASE=$([ -f /etc/environment ] && source /etc/environment && echo $LATEST_RELEASE || curl -s https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/latest | jq -r '.tag_name') && \
-    RESPONSE=$(curl -s https://api.github.com/repos/${GITHUB_USER}/${GITHUB_REPO}/releases/latest) && \
-    DOWNLOAD_URL=$(echo $RESPONSE | jq -r '.assets[] | select(.name | endswith("OpenMS-App.zip")) | .browser_download_url') && \
-    if [ -z "$DOWNLOAD_URL" ]; then \
-        echo "Error: Could not find OpenMS-App.zip in the latest release assets" && \
-        exit 1; \
-    fi && \
-    wget -O /app/OpenMS-App.zip $DOWNLOAD_URL && \
-    unzip /app/OpenMS-App.zip -d /app/OpenMS-App && \
-    rm /app/OpenMS-App.zip
 
 # make sure that mamba environment is used
 SHELL ["mamba", "run", "-n", "streamlit-env", "/bin/bash", "-c"]

--- a/settings.json
+++ b/settings.json
@@ -12,5 +12,6 @@
             "tag": "57690c44-d635-43b0-ab43-f8bd3064ca06"
         }
     },
-    "online_deployment": false
+    "online_deployment": false,
+    "version": "0.0.0"
 }


### PR DESCRIPTION
When a new release is created the github action build-windows-executable-app.yaml it is running and the resulting installer should be uploaded as release asset.

the Dockerfile (and Dockerfile_simple) are now using the latest release asset.

The version number should also be added to the settings.json file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The application now automatically updates its version based on the latest release, ensuring users always see the current version.
	- The deployment process has been enhanced with a simplified method for downloading the OpenMS App, improving reliability and efficiency.
- **Bug Fixes**
	- Improved error handling during installation ensures that the download process is skipped if the GitHub token is not set.
- **Updates**
	- Added a new version tracking feature in the application settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->