### PR TITLE
Adding OpenMs installation in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,13 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install OpenMS
+      run: |
+        conda create -n openms python=3.10
+        conda config --add channels defaults
+        conda config --add channels bioconda
+        conda config --add channels conda-forge
+        conda install openms
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Fixes #137 

Adding installation for `OpenMs` via conda. Documentation followed https://openms.readthedocs.io/en/latest/about/installation/installation-on-gnu-linux.html#install-via-conda