### PR TITLE
Fix: Update app.py to display app name and version from settings.json (#140)

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,9 +3,13 @@ from pathlib import Path
 # For some reason the windows version only works if this is imported here
 import pyopenms
 
+if "settings" not in st.session_state:
+        with open("settings.json", "r") as f:
+            st.session_state.settings = json.load(f)
+
 if __name__ == '__main__':
     pages = {
-        "OpenMS Web App" : [
+        f"{st.session_state.settings["app-name"]} - {st.session_state.settings["version"]}" : [
             st.Page(Path("content", "quickstart.py"), title="Quickstart", icon="👋"),
             st.Page(Path("content", "documentation.py"), title="Documentation", icon="📖"),
         ],


### PR DESCRIPTION
feat: Retrieve app name and version from settings.json

Retrieves the application name and version from the `settings.json` file. we will get a ValueError if the 'version' key is not found in settings.json

added image for your reference. 

![image](https://github.com/user-attachments/assets/af8eacdd-ea6c-4cfd-b820-c6bdaf94b483)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The application now dynamically displays its name and version based on external configuration, ensuring that the branding information is automatically updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->