### PR TITLE
Fix: Display WebApp Versioning 

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,7 +10,7 @@ if "settings" not in st.session_state:
 
 if __name__ == '__main__':
     pages = {
-        f"{st.session_state.settings["app-name"]}" : [
+        str(st.session_state.settings["app-name"]) : [
             st.Page(Path("content", "quickstart.py"), title="Quickstart", icon="👋"),
             st.Page(Path("content", "documentation.py"), title="Documentation", icon="📖"),
         ],

--- a/app.py
+++ b/app.py
@@ -1,11 +1,16 @@
 import streamlit as st
 from pathlib import Path
+import json
 # For some reason the windows version only works if this is imported here
 import pyopenms
 
+if "settings" not in st.session_state:
+        with open("settings.json", "r") as f:
+            st.session_state.settings = json.load(f)
+
 if __name__ == '__main__':
     pages = {
-        "OpenMS Web App" : [
+        f"{st.session_state.settings["app-name"]}" : [
             st.Page(Path("content", "quickstart.py"), title="Quickstart", icon="👋"),
             st.Page(Path("content", "documentation.py"), title="Documentation", icon="📖"),
         ],

--- a/settings.json
+++ b/settings.json
@@ -1,6 +1,7 @@
 {
     "app-name": "OpenMS WebApp Template",
     "github-user": "OpenMS",
+    "version": "1.0.2",
     "repository-name": "streamlit-template",
     "analytics": {
         "google-analytics": {

--- a/src/common/common.py
+++ b/src/common/common.py
@@ -322,6 +322,23 @@ def render_sidebar(page: str = "") -> None:
                 )
             else:
                 st.session_state["spectrum_num_bins"] = 50
+        
+        # Display OpenMS WebApp Template Version from settings.json 
+        with st.container():
+            st.markdown(
+                """
+                <style>
+                .version-box {
+                    border: 1px solid #a4a5ad; 
+                    padding: 10px;
+                    border-radius: 0.5rem; 
+                }
+                </style>
+                """,
+                unsafe_allow_html=True
+            )
+            version_info = st.session_state.settings["version"]  
+            st.markdown(f'<div class="version-box"><b>OpenMS WebApp:<b/> V{version_info}</div>', unsafe_allow_html=True)
     return params
 
 

--- a/src/common/common.py
+++ b/src/common/common.py
@@ -341,8 +341,9 @@ def render_sidebar(page: str = "") -> None:
                 """,
                 unsafe_allow_html=True
             )
-            version_info = st.session_state.settings["version"]  
-            st.markdown(f'<div class="version-box"><b>OpenMS WebApp: V{version_info}</b></div>', unsafe_allow_html=True)
+            version_info = st.session_state.settings["version"] 
+            app_name = st.session_state.settings["app-name"] 
+            st.markdown(f'<div class="version-box">{app_name}<br>Version: V{version_info}</div>', unsafe_allow_html=True)
     return params
 
 

--- a/src/common/common.py
+++ b/src/common/common.py
@@ -343,7 +343,7 @@ def render_sidebar(page: str = "") -> None:
             )
             version_info = st.session_state.settings["version"] 
             app_name = st.session_state.settings["app-name"] 
-            st.markdown(f'<div class="version-box">{app_name}<br>Version: V{version_info}</div>', unsafe_allow_html=True)
+            st.markdown(f'<div class="version-box">{app_name}<br>Version: {version_info}</div>', unsafe_allow_html=True)
     return params
 
 

--- a/src/common/common.py
+++ b/src/common/common.py
@@ -331,14 +331,18 @@ def render_sidebar(page: str = "") -> None:
                 .version-box {
                     border: 1px solid #a4a5ad; 
                     padding: 10px;
-                    border-radius: 0.5rem; 
+                    border-radius: 0.5rem;
+                    text-align: center;
+                    display: flex;
+                    justify-content: center;
+                    align-items: center; 
                 }
                 </style>
                 """,
                 unsafe_allow_html=True
             )
             version_info = st.session_state.settings["version"]  
-            st.markdown(f'<div class="version-box"><b>OpenMS WebApp:<b/> V{version_info}</div>', unsafe_allow_html=True)
+            st.markdown(f'<div class="version-box"><b>OpenMS WebApp: V{version_info}</b></div>', unsafe_allow_html=True)
     return params
 
 


### PR DESCRIPTION
### Update app name and version display from settings #140 

- Updated app.py to display the app name from settings.json. 

- Updated common.py to display the version in the web UI from settings.py. 

### Testing 

- [x] checked on light theme
- [x] checked on dark theme
- [x] app name from settings visible in the UI

> if key version is not present in the settings.json we will get ValueError 

![image](https://github.com/user-attachments/assets/98b276ea-ee6f-4068-8f52-d5eb5289d602)
![image](https://github.com/user-attachments/assets/2f6d2f2e-2aa3-4026-a9a1-c7e6baaf4df8)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The application now loads its settings from an external configuration file, allowing dynamic updates to key information such as the app name.
	- The sidebar now displays the application version (1.0.2), providing clear visibility of the current release for tracking purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->