### PR TITLE
Configure size upload limit

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -2,10 +2,10 @@
 developmentMode = false
 
 [server]
+maxUploadSize = 200  #MB
 port = 8501 # should be same as configured in deployment repo
 
 [theme]
-
 # The preset Streamlit theme that your custom theme inherits from. One of "light" or "dark".
 # base =
 

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -2,7 +2,7 @@
 developmentMode = false
 
 [server]
-maxUploadSize =  500 #MB
+maxUploadSize =  200 #MB
 port = 8501 # should be same as configured in deployment repo
 
 [theme]

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -2,7 +2,7 @@
 developmentMode = false
 
 [server]
-maxUploadSize = 200  #MB
+maxUploadSize =  5000 #5GB
 port = 8501 # should be same as configured in deployment repo
 
 [theme]

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -2,7 +2,7 @@
 developmentMode = false
 
 [server]
-maxUploadSize =  5000 #5GB
+maxUploadSize =  500 #MB
 port = 8501 # should be same as configured in deployment repo
 
 [theme]

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -15,15 +15,24 @@ In the OpenMS web application, workspaces are designed to keep your analysis org
 - **Workspace Specific Parameters and Files**: Each workspace stores parameters and files (uploaded input files and results from workflows).
 - **Persistence**: Your workspaces and parameters are saved, so you can return to your analysis anytime and pick up where you left off. Simply bookmark the page!
 
-## Online and Local Mode Differences
+### File Uploads
+- **Online Mode**: You can upload only one file at a time. This helps manage server load and optimizes performance.
 
-There are a few key differences between operating in online and local modes:
-- **File Uploads**:
-  - *Online Mode*: You can upload only one file at a time. This helps manage server load and optimizes performance.
-  - *Local Mode*: Multiple file uploads are supported, giving you flexibility when working with large datasets.
-- **Workspace Access**:
-  - In online mode, workspaces are stored temporarily and will be cleared after seven days of inactivity.
-  - In local mode, workspaces are saved on your local machine, allowing for persistent storage.
+- **Local Mode**: Multiple file uploads are supported, giving you flexibility when working with large datasets. Additionally, the file size upload limit can be adjusted in the following ways:
+  1. **Using `.streamlit/config.toml`**:
+     - You can modify the `.streamlit/config.toml` file and set the `maxUploadSize` parameter to your desired value. By default, this is set to 200MB.
+     - Example:
+       ```toml
+       [server]
+       maxUploadSize = 500  # Set the upload limit to 500MB
+       ```
+  2. **Using CLI Command**:
+     - You can customize the file size upload limit directly when running the application using the `--server.maxUploadSize` argument.
+     - Example:
+       ```bash
+       python run_app.py --server.maxUploadSize 500
+       ```
+     - This sets the upload limit to 500MB for the current session.
 
 ## Downloading Results
 

--- a/run_app.py
+++ b/run_app.py
@@ -1,7 +1,29 @@
-from streamlit.web import cli
+import argparse
+import json
+import subprocess
+
+# Default upload size (MB) if settings.json is missing/invalid
+DEFAULT_MAX_SIZE = 200
+
+def get_upload_limit():
+    """Read max upload size from settings.json or use default."""
+    try:
+        with open("settings.json") as f:
+            return json.load(f).get("maximum_file_upload_size", DEFAULT_MAX_SIZE)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return DEFAULT_MAX_SIZE
 
 if __name__ == "__main__":
-    cli._main_run_clExplicit(
-        file="app.py", command_line="streamlit run"
-    )
-    # we will create this function inside our streamlit framework
+    # Parse command-line arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--max-upload', type=int, help='Override upload size (MB)')
+    args, unknown = parser.parse_known_args()
+    
+    # Priority: Command-line > settings.json > default
+    size = args.max_upload or get_upload_limit()
+    
+    # Run Streamlit with the configured upload size
+    subprocess.run([
+        "streamlit", "run", "app.py",
+        "--server.maxUploadSize", str(size)
+    ] + unknown)  # Pass through additional arguments

--- a/run_app.py
+++ b/run_app.py
@@ -1,5 +1,5 @@
 from streamlit.web import cli
-import sys
+
 
 if __name__ == "__main__":
     cli._main_run_clExplicit(

--- a/run_app.py
+++ b/run_app.py
@@ -1,6 +1,8 @@
-from streamlit.web.cli import main
+from streamlit.web import cli
 import sys
 
 if __name__ == "__main__":
-    sys.argv = ["streamlit", "run", "app.py"]
-    main()
+    cli._main_run_clExplicit(
+        file="app.py", 
+        command_line="streamlit run"
+    )

--- a/run_app.py
+++ b/run_app.py
@@ -1,26 +1,6 @@
-import subprocess
+from streamlit.web.cli import main
 import sys
-from streamlit.logger import get_logger
-
-# Initialize a logger for this module
-logger = get_logger(__name__)
 
 if __name__ == "__main__":
-    try:
-        # Construct the command to run the Streamlit app, including any additional command-line arguments
-        cmd = ["streamlit", "run", "app.py"] + sys.argv[1:]
-        
-        # Log the constructed command at the debug level
-        logger.debug(f"Running command: {' '.join(cmd)}")
-        
-        # Execute the command and check for errors
-        subprocess.run(cmd, check=True)
-        
-    except subprocess.CalledProcessError as e:
-        # Log an error message if the Streamlit command fails
-        logger.error(f"Streamlit failed to run (error code {e.returncode})")
-        sys.exit(1)
-    except Exception as e:
-        # Log any unexpected errors that occur during execution
-        logger.error(f"Unexpected error: {str(e)}")
-        sys.exit(1)
+    sys.argv = ["streamlit", "run", "app.py"]
+    main()

--- a/settings.json
+++ b/settings.json
@@ -2,7 +2,6 @@
     "app-name": "OpenMS WebApp Template",
     "github-user": "OpenMS",
     "repository-name": "streamlit-template",
-    "maximum_file_upload_size": 200,
     "analytics": {
         "google-analytics": {
             "enabled": false,

--- a/settings.json
+++ b/settings.json
@@ -2,6 +2,7 @@
     "app-name": "OpenMS WebApp Template",
     "github-user": "OpenMS",
     "repository-name": "streamlit-template",
+    "maximum_file_upload_size": 200,
     "analytics": {
         "google-analytics": {
             "enabled": false,


### PR DESCRIPTION
feat: Add configurable file upload size via settings.json and CLI

- Added `maximum_file_upload_size` parameter to settings.json
- Implemented priority logic: CLI > settings.json > default (200MB)
- Updated run_app.py to handle upload size configuration
- Removed redundant Streamlit CLI code to avoid conflicts

Resolves #155

@jcharkow Please review the PR and let me know if any changes are needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved readability of the application’s startup process by restructuring parameter calls.

- **New Features**
  - Introduced a configuration option to set the maximum file upload limit to 200MB.
  - Expanded and reorganized user documentation to clarify file upload limits and customization methods in local mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->