### PR TITLE
Temp Fix for Windows CI

### DIFF
--- a/.github/workflows/build-windows-executable-app-with-pyinstaller.yaml
+++ b/.github/workflows/build-windows-executable-app-with-pyinstaller.yaml
@@ -25,8 +25,8 @@ jobs:
         git config user.name "GitHub Actions"
         git config user.email "actions@github.com"
         git fetch origin develop
-        git checkout develop -- tools/ci/cibuild.cmake
-        git checkout develop -- tools/ci/citest.cmake
+        git checkout origin/develop -- tools/ci/cibuild.cmake
+        git checkout origin/develop -- tools/ci/citest.cmake
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v3

--- a/.github/workflows/build-windows-executable-app-with-pyinstaller.yaml
+++ b/.github/workflows/build-windows-executable-app-with-pyinstaller.yaml
@@ -18,6 +18,15 @@ jobs:
         ref: release/${{ env.OPENMS_VERSION }}
         path: 'OpenMS'
 
+    # Temporary fix - until seqan is back online or new OpenMS release (3.4)
+    - name: Cherry-pick commit
+      working-directory: OpenMS
+      run: |
+        git config user.name "GitHub Actions"
+        git config user.email "actions@github.com"
+        git fetch origin
+        git cherry-pick ccb989e
+
     - name: Install Qt
       uses: jurplel/install-qt-action@v3
       with:

--- a/.github/workflows/build-windows-executable-app-with-pyinstaller.yaml
+++ b/.github/workflows/build-windows-executable-app-with-pyinstaller.yaml
@@ -24,7 +24,7 @@ jobs:
       run: |
         git config user.name "GitHub Actions"
         git config user.email "actions@github.com"
-        git fetch develop
+        git fetch origin develop
         git checkout develop -- tools/ci/cibuild.cmake
         git checkout develop -- tools/ci/citest.cmake
 

--- a/.github/workflows/build-windows-executable-app-with-pyinstaller.yaml
+++ b/.github/workflows/build-windows-executable-app-with-pyinstaller.yaml
@@ -27,6 +27,7 @@ jobs:
         git fetch origin develop
         git checkout origin/develop -- tools/ci/cibuild.cmake
         git checkout origin/develop -- tools/ci/citest.cmake
+        git checkout origin/develop -- tools/ci/cipackage.cmake
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v3

--- a/.github/workflows/build-windows-executable-app-with-pyinstaller.yaml
+++ b/.github/workflows/build-windows-executable-app-with-pyinstaller.yaml
@@ -19,13 +19,14 @@ jobs:
         path: 'OpenMS'
 
     # Temporary fix - until seqan is back online or new OpenMS release (3.4)
-    - name: Cherry-pick commit
+    - name: Get latest cibuild.cmake
       working-directory: OpenMS
       run: |
         git config user.name "GitHub Actions"
         git config user.email "actions@github.com"
-        git fetch origin
-        git cherry-pick ccb989e
+        git fetch develop
+        git checkout develop -- tools/ci/cibuild.cmake
+        git checkout develop -- tools/ci/citest.cmake
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v3

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -29,13 +29,14 @@ jobs:
         path: 'OpenMS'
     
     # Temporary fix - until seqan is back online or new OpenMS release (3.4)
-    - name: Cherry-pick commit
+    - name: Get latest cibuild.cmake
       working-directory: OpenMS
       run: |
         git config user.name "GitHub Actions"
         git config user.email "actions@github.com"
-        git fetch origin
-        git cherry-pick ccb989e
+        git fetch develop
+        git checkout develop -- tools/ci/cibuild.cmake
+        git checkout develop -- tools/ci/citest.cmake
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v4

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -34,7 +34,7 @@ jobs:
       run: |
         git config user.name "GitHub Actions"
         git config user.email "actions@github.com"
-        git fetch develop
+        git fetch origin develop
         git checkout develop -- tools/ci/cibuild.cmake
         git checkout develop -- tools/ci/citest.cmake
 

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -27,6 +27,15 @@ jobs:
         repository: OpenMS/OpenMS
         ref: release/${{ env.OPENMS_VERSION }}
         path: 'OpenMS'
+    
+    # Temporary fix - until seqan is back online or new OpenMS release (3.4)
+    - name: Cherry-pick commit
+      working-directory: OpenMS
+      run: |
+        git config user.name "GitHub Actions"
+        git config user.email "actions@github.com"
+        git fetch origin
+        git cherry-pick ccb989e
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v4

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -35,8 +35,8 @@ jobs:
         git config user.name "GitHub Actions"
         git config user.email "actions@github.com"
         git fetch origin develop
-        git checkout develop -- tools/ci/cibuild.cmake
-        git checkout develop -- tools/ci/citest.cmake
+        git checkout origin/develop -- tools/ci/cibuild.cmake
+        git checkout origin/develop -- tools/ci/citest.cmake
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v4

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -37,6 +37,7 @@ jobs:
         git fetch origin develop
         git checkout origin/develop -- tools/ci/cibuild.cmake
         git checkout origin/develop -- tools/ci/citest.cmake
+        git checkout origin/develop -- tools/ci/cipackage.cmake
 
     - name: Install Qt
       uses: jurplel/install-qt-action@v4


### PR DESCRIPTION
Cdash on seqan is currently not working. This PR fixes this temporarily by applying the fix from the main repository (will only be included in the openms 3.4 release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced the Windows executable build process by adding a new automation step to fetch the latest configuration files.
  - Improved workflow stability to ensure reliable build outputs while external dependencies undergo updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->