### PR TITLE
fix : Workflows are not terminated if errors are detected

### DIFF
--- a/src/workflow/CommandExecutor.py
+++ b/src/workflow/CommandExecutor.py
@@ -105,6 +105,7 @@ class CommandExecutor:
         if stderr or process.returncode != 0:
             error_message = stderr.decode().strip()
             self.logger.log(f"ERRORS OCCURRED:\n{error_message}", 2)
+            raise RuntimeError(f"Process failed: {error_message}")
 
     def run_topp(self, tool: str, input_output: dict, custom_params: dict = {}) -> None:
         """

--- a/src/workflow/WorkflowManager.py
+++ b/src/workflow/WorkflowManager.py
@@ -50,7 +50,7 @@ class WorkflowManager:
             self.execution()
             self.logger.log("WORKFLOW FINISHED")
         except Exception as e:
-            self.logger.log(f"ERROR: {e}")
+            self.logger.log(f"ERROR: {str(e).splitlines()[0].strip()}")
         # Delete pid dir path to indicate workflow is done
         shutil.rmtree(self.executor.pid_dir, ignore_errors=True)
 


### PR DESCRIPTION
- Added error raising on line 108 to halt workflow execution when an error occurs. 
- Implemented level 2 logging for the initial error. 
- Captured and logged the first line of the error at level 0 for user visibility. 
- Ensures workflow termination and proper error reporting.

- This will resolve issue #154 