### PR TITLE
feat: add cpu and ram visualiser

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,3 +15,4 @@ dependencies:
         - captcha==0.5.0
         - pyopenms_viz==1.0.0
         - streamlit-js-eval
+        - psutil==7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ plotly==5.22.0
 captcha==0.5.0
 pyopenms_viz==1.0.0
 streamlit-js-eval
+psutil==7.0.0

--- a/src/common/common.py
+++ b/src/common/common.py
@@ -10,7 +10,7 @@ from streamlit.components.v1 import html
 
 import streamlit as st
 import pandas as pd
-
+import psutil
 try:
     from tkinter import Tk, filedialog
 
@@ -23,6 +23,18 @@ from src.common.captcha_ import captcha_control
 # Detect system platform
 OS_PLATFORM = sys.platform
 
+@st.fragment(run_every=5)
+def monitor_hardware():
+    cpu_progress = psutil.cpu_percent(interval=None) / 100
+    ram_progress = 1 - psutil.virtual_memory().available / psutil.virtual_memory().total
+
+    st.text(f"Ram ({ram_progress * 100:.2f}%)")
+    st.progress(ram_progress)
+
+    st.write(f"CPU ({cpu_progress * 100:.2f}%)")
+    st.progress(cpu_progress)
+
+    st.text(f"Last fetched at: {time.strftime('%H:%M:%S')}")
 
 def load_params(default: bool = False) -> dict[str, Any]:
     """
@@ -279,6 +291,9 @@ def render_sidebar(page: str = "") -> None:
     """
     params = load_params()
     with st.sidebar:
+        with st.expander("📊 **CPU Visualisation**"):
+            monitor_hardware()
+        
         # The main page has workspace switcher
         # Display workspace switcher if workspace is enabled in local mode
         if st.session_state.settings["enable_workspaces"]:
@@ -347,7 +362,7 @@ def render_sidebar(page: str = "") -> None:
                     "Number of Bins (m/z)", 1, 10000, 50, key="spectrum_num_bins"
                 )
             else:
-                st.session_state["spectrum_num_bins"] = 50
+                st.session_state["spectrum_num_bins"] = 50            
         
         # Display OpenMS WebApp Template Version from settings.json 
         with st.container():

--- a/src/common/common.py
+++ b/src/common/common.py
@@ -31,10 +31,10 @@ def monitor_hardware():
     st.text(f"Ram ({ram_progress * 100:.2f}%)")
     st.progress(ram_progress)
 
-    st.write(f"CPU ({cpu_progress * 100:.2f}%)")
+    st.text(f"CPU ({cpu_progress * 100:.2f}%)")
     st.progress(cpu_progress)
 
-    st.text(f"Last fetched at: {time.strftime('%H:%M:%S')}")
+    st.caption(f"Last fetched at: {time.strftime('%H:%M:%S')}")
 
 def load_params(default: bool = False) -> dict[str, Any]:
     """

--- a/src/common/common.py
+++ b/src/common/common.py
@@ -291,9 +291,6 @@ def render_sidebar(page: str = "") -> None:
     """
     params = load_params()
     with st.sidebar:
-        with st.expander("📊 **CPU Visualisation**"):
-            monitor_hardware()
-        
         # The main page has workspace switcher
         # Display workspace switcher if workspace is enabled in local mode
         if st.session_state.settings["enable_workspaces"]:
@@ -362,7 +359,10 @@ def render_sidebar(page: str = "") -> None:
                     "Number of Bins (m/z)", 1, 10000, 50, key="spectrum_num_bins"
                 )
             else:
-                st.session_state["spectrum_num_bins"] = 50            
+                st.session_state["spectrum_num_bins"] = 50
+
+        with st.expander("📊 **Resource Utilization**"):
+            monitor_hardware()      
         
         # Display OpenMS WebApp Template Version from settings.json 
         with st.container():


### PR DESCRIPTION
Fixes: #124 

- Used `st.fragment` with `re-run` to check cpu and ram stats every **5 seconds**
- Added this new section to the sidebar

### Recording
https://github.com/user-attachments/assets/5c2db64d-e84b-4402-a3cb-a5cef6fcf38d



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new sidebar section that displays real-time system performance metrics, including CPU and memory usage with periodic updates.
  - Introduced a new dependency, `psutil==7.0.0`, to enhance system monitoring capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->