### PR TITLE
Bugfix : added warning to reject empty workspace names

### DIFF
--- a/src/common/common.py
+++ b/src/common/common.py
@@ -211,7 +211,7 @@ def page_setup(page: str = "") -> dict[str, Any]:
         if st.session_state.settings["workspaces_dir"] and st.session_state.location == "local":
             workspaces_dir = Path(st.session_state.settings["workspaces_dir"], "workspaces-" + st.session_state.settings["repository-name"])
         else:
-            workspace_dir = '..'
+            workspaces_dir = '..'
             
         # Check if workspace logic is enabled
         if st.session_state.settings["enable_workspaces"]:

--- a/src/common/common.py
+++ b/src/common/common.py
@@ -313,16 +313,19 @@ def render_sidebar(page: str = "") -> None:
                         key="chosen-workspace",
                     )
                     # Create or Remove workspaces
-                    create_remove = st.text_input("create/remove workspace", "")
+                    create_remove = st.text_input("create/remove workspace", "").strip()
                     path = Path(workspaces_dir, create_remove)
                     # Create new workspace
                     if st.button("**Create Workspace**"):
-                        path.mkdir(parents=True, exist_ok=True)
-                        st.session_state.workspace = path
-                        st.query_params.workspace = create_remove
-                        # Temporary as the query update takes a short amount of time
-                        time.sleep(1)
-                        st.rerun()
+                        if create_remove:
+                            path.mkdir(parents=True, exist_ok=True)
+                            st.session_state.workspace = path
+                            st.query_params.workspace = create_remove
+                            # Temporary as the query update takes a short amount of time
+                            time.sleep(1)
+                            st.rerun()
+                        else:
+                            st.warning("Please enter a valid workspace name.")
                     # Remove existing workspace and fall back to default
                     if st.button("⚠️ Delete Workspace"):
                         if path.exists():


### PR DESCRIPTION
fixes #178

Earlier, upon entering an empty workspace name and pressing the create workspace button, the website used to crash. Now that is resolved by showing a warning
![image](https://github.com/user-attachments/assets/0c8d10f2-3b7b-4d10-92d4-e93b3261951b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the workspace creation process to automatically trim extra spaces from user inputs. Now, if a workspace name is left empty or consists solely of whitespace, a warning message is displayed prompting for a valid name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->