### PR TITLE
Testing `window exec work with pyinstaller with latest version of streamlit`

### DIFF
--- a/.github/workflows/test-win-exe-w-pyinstaller.yaml
+++ b/.github/workflows/test-win-exe-w-pyinstaller.yaml
@@ -97,7 +97,7 @@ jobs:
         cp D:/a/streamlit-template/streamlit-template/myenv/Lib/site-packages/streamlit/web/cli.py artifacts/ 
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: Outfolders
         path: artifacts


### PR DESCRIPTION
Testing `window exec work with pyinstaller with latest version of streamlit`. Testing details are given below :

>test using streamlit latest version `Streamlit v1.43.2`

- Fix: #180 

build the exec file using [test-win-ese-w-pyinstaller.yaml](https://github.com/OpenMS/streamlit-template/blob/main/.github/workflows/test-win-exe-w-pyinstaller.yaml)
build is failing as check [ actions/runs/14052911680 ](https://github.com/jitendra-ky/streamlit-template/actions/runs/14052911680) 
![image](https://github.com/user-attachments/assets/d47bde0d-8799-4af6-9833-4ac290bd43a4)

---
- Do some Fix and rerun the same `test-win-ese-w-pyinstaller.yaml` ( same attached in this PR )
- then Build completed successfully check [test-win-ese-w-pyinstaller.yaml](https://github.com/jitendra-ky/streamlit-template/actions/runs/14053010641)
- download the artifacts and run `run_app.exe`
- ✅and it run successfully.
- Deep testing of each page not yet performed – would like to know if there's a specific checklist for testing.
- I cross check the version of streamlit by and about section of app.
![image](https://github.com/user-attachments/assets/03171b0a-e3a3-452b-a9f6-22cba2a5f6ea)

---
while testing found a bug:
- when run `run_app.exe` the terminal prompts
![image](https://github.com/user-attachments/assets/32bd9b01-a7cb-4bc0-bd16-a8b20b249a57)
- and `localhost:3000` automatically opens in the web-browser
- but the server was running on `localhost:8501`

---
while testing I also found that [win_exe_with_pyinstaller.md](https://github.com/OpenMS/streamlit-template/blob/main/docs/win_exe_with_pyinstaller.md) docs are outdated
for that I raised a separate PR please check
- #207 