### PR TITLE
fix : OpenMS Executable Release Artifact Upload Issue

### DIFF
--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -8,6 +8,10 @@ on:
     types: [created]
   workflow_dispatch:
   
+# Add permissions block to allow upload to releases
+permissions:
+  contents: write
+
 env:
   OPENMS_VERSION: 3.2.0 
   PYTHON_VERSION: 3.11.0
@@ -442,5 +446,5 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         files: OpenMS-App.zip
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ github.token }}
+

--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -447,4 +447,3 @@ jobs:
       with:
         files: OpenMS-App.zip
         token: ${{ github.token }}
-


### PR DESCRIPTION


Issue #204 .

## Solution
Modified the `Upload Artifact as Release Asset` step in the `.github/workflows/build-windows-executable-app.yaml` file to use the token parameter in the `with` section instead of providing it via an environment variable:

This change ensures the action receives the token in the expected format, resolving the permission issues encountered previously.

## Testing
<img width="1390" alt="Image" src="https://github.com/user-attachments/assets/75212ebe-cd21-481a-956b-7f3a690ab0fe" />

Tested here - https://github.com/achalbajpai/streamlit-template/actions/runs/14062569971/job/39378083013

## Related Issues
✅  Closes #204


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Enhanced our build and release automation to securely and reliably upload release assets. These improvements ensure a smoother download and update experience for users. 
	- Updated permissions and token management in the workflow for improved functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->