### PR TITLE
Throw exception on ERROR and terminate TOPP workflow run

### DIFF
--- a/src/workflow/CommandExecutor.py
+++ b/src/workflow/CommandExecutor.py
@@ -105,6 +105,7 @@ class CommandExecutor:
         if stderr or process.returncode != 0:
             error_message = stderr.decode().strip()
             self.logger.log(f"ERRORS OCCURRED:\n{error_message}", 2)
+            raise RuntimeError(error_message)
 
     def run_topp(self, tool: str, input_output: dict, custom_params: dict = {}) -> None:
         """


### PR DESCRIPTION
Fixes #154 

### Description
I've added a new raise exception block that throws an exception to be caught by the outermost try / catch block at the workflow run level to terminate the workflow run


https://github.com/user-attachments/assets/1be2fe5f-2dec-407c-a2be-719b0c4ef2c0

 