### PR TITLE
Fix: Correct return type of get_parameters_from_json in ParameterManager.py

### DIFF
--- a/src/workflow/ParameterManager.py
+++ b/src/workflow/ParameterManager.py
@@ -77,7 +77,7 @@ class ParameterManager:
         with open(self.params_file, "w", encoding="utf-8") as f:
             json.dump(json_params, f, indent=4)
 
-    def get_parameters_from_json(self) -> None:
+    def get_parameters_from_json(self) -> dict:
         """
         Loads parameters from the JSON file if it exists and returns them as a dictionary.
         If the file does not exist, it returns an empty dictionary.


### PR DESCRIPTION
###  What Changed

Corrected the return type annotation of the `get_parameters_from_json` method in `ParameterManager.py`.

### 🐞 Problem

Previously, the function was annotated as:
```python
def get_parameters_from_json(self) -> None:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Parameter loading now returns a full set of configuration settings as a structured dictionary, providing clearer access to parameters.

- **Documentation**
  - Updated descriptions to reflect the enhanced output format for parameter retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->