### PR TITLE
Fix: Correct return type of get_parameters_from_json

### DIFF
--- a/src/workflow/ParameterManager.py
+++ b/src/workflow/ParameterManager.py
@@ -77,7 +77,7 @@ class ParameterManager:
         with open(self.params_file, "w", encoding="utf-8") as f:
             json.dump(json_params, f, indent=4)
 
-    def get_parameters_from_json(self) -> None:
+    def get_parameters_from_json(self) -> dict:
         """
         Loads parameters from the JSON file if it exists and returns them as a dictionary.
         If the file does not exist, it returns an empty dictionary.


### PR DESCRIPTION
Updated the return type annotation of the get_parameters_from_json method in ParameterManager.py from None to dict to accurately reflect its returned value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced parameter loading to reliably deliver complete configuration data in a structured format. Now, when no parameters are available, an empty result is provided, ensuring consistent and clear behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->