### PR TITLE
TOPP execution: show log, just after clicking `start workflow`.

### DIFF
--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -1024,6 +1024,10 @@ class StreamlitUI:
                     if not "WORKFLOW FINISHED" in content:
                         st.error("**Errors occurred, check log file.**")
                     st.code(content, language="neon", line_numbers=False)
+        else:
+            # as log file is not created yet
+            time.sleep(1)
+            st.rerun()
 
     def results_section(self, custom_results_function) -> None:
         custom_results_function()


### PR DESCRIPTION
- Fix: #225

## before 
logs are not visible after starting the workflow, until again click on 'minimal'

https://github.com/user-attachments/assets/be71c6ea-bd26-49ca-a6ee-a4d4f230c712

## after
live logs are visible automatically just after clicking `start workflow`

https://github.com/user-attachments/assets/f5ec6528-e661-4e89-a688-99eb90559ebc



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced workflow responsiveness: The application now automatically pauses briefly and reattempts operations when expected data isn’t yet available. This adjustment minimizes interruptions and delivers a smoother, more consistent execution experience for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->