### PR TITLE
Update Dockerfile for pyopenms-viz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ RUN pip install dist/*.whl
 
 # Install other dependencies (excluding pyopenms)
 COPY requirements.txt ./requirements.txt 
-RUN grep -v '^pyopenms' requirements.txt > requirements_cleaned.txt && mv requirements_cleaned.txt requirements.txt
+RUN grep -Ev '^pyopenms([=<>!~].*)?$' requirements.txt > requirements_cleaned.txt && mv requirements_cleaned.txt requirements.txt
 RUN pip install -r requirements.txt
 
 WORKDIR /


### PR DESCRIPTION
- before also remove pyopenms-viz
- now it will not take out any package with name pyopenms- or pyopenms_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved handling of dependency exclusions to more reliably omit all variants of the pyopenms package during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->