### PR TITLE
Use Windows 2022 Runner

### DIFF
--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -24,7 +24,7 @@ env:
 
 jobs:
   build-openms:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - name: Checkout
@@ -185,7 +185,7 @@ jobs:
         path: ${{ github.workspace }}/OpenMS/bld/*.zip
 
   build-executable:
-    runs-on: windows-latest
+    runs-on: windows-2022
     needs: build-openms  
 
     steps:


### PR DESCRIPTION
More consistency with OpenMS CI build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows build environment to Windows Server 2022 for build pipelines, improving build consistency and reliability.
  * No changes to application features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->