### PR TITLE
Use symlinks on Linux for demo and example files

### DIFF
--- a/src/fileupload.py
+++ b/src/fileupload.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import streamlit as st
 
-from src.common.common import reset_directory
+from src.common.common import reset_directory, OS_PLATFORM
 
 
 @st.cache_data
@@ -73,6 +73,8 @@ def load_example_mzML_files() -> None:
     """
     Copies example mzML files to the mzML directory.
 
+    On Linux, creates symlinks to example files instead of copying them.
+
     Args:
         None
 
@@ -80,9 +82,15 @@ def load_example_mzML_files() -> None:
         None
     """
     mzML_dir = Path(st.session_state.workspace, "mzML-files")
-    # Copy files from example-data/mzML to workspace mzML directory, add to selected files
+    # Copy or symlink files from example-data/mzML to workspace mzML directory
     for f in Path("example-data", "mzML").glob("*.mzML"):
-        shutil.copy(f, mzML_dir)
+        target = mzML_dir / f.name
+        if OS_PLATFORM == "linux":
+            if target.exists():
+                target.unlink()
+            target.symlink_to(f.resolve())
+        else:
+            shutil.copy(f, mzML_dir)
     st.success("Example mzML files loaded!")
 
 


### PR DESCRIPTION
## Summary
Optimize file handling on Linux by using symlinks instead of copying demo workspaces and example files. This reduces disk space usage and improves performance while maintaining the ability for users to add new files to workspace directories.

## Key Changes
- Added `_symlink_tree()` helper function to recursively create directory structures with symlinked files
- Modified `copy_demo_workspace()` to use symlinks on Linux and traditional copying on other platforms
- Updated demo data loading in `change_workspace()` to use symlinks on Linux
- Updated `load_example_mzML_files()` to use symlinks on Linux
- Updated docstrings to document the platform-specific behavior

## Implementation Details
- Symlinks are created to resolved absolute paths to ensure they work correctly
- Real directories are created (not symlinked) to allow users to add new files without affecting the original demo/example data
- The implementation checks `OS_PLATFORM == "linux"` to determine which approach to use
- Existing target files/directories are properly cleaned up before creating symlinks
- Non-Linux platforms continue to use the original `shutil.copytree()` and `shutil.copy()` behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Demo workspaces on Linux now use symlinks for more efficient file handling.
  * Example files are symlinked on Linux systems instead of being copied; standard copying behavior continues on other platforms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->