### PR TITLE
Remove progress bar visualizations from queue and job status

### DIFF
--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -1217,17 +1217,9 @@ class StreamlitUI:
             queue_length = status.get("queue_length", "?")
             st.info(f"**Status: {label}** - Your workflow is #{queue_position} in the queue ({queue_length} total jobs)")
 
-            # Visual queue indicator
-            if isinstance(queue_position, int) and isinstance(queue_length, int) and queue_length > 0:
-                progress = 1 - (queue_position / queue_length)
-                st.progress(progress, text=f"Queue position {queue_position} of {queue_length}")
-
         elif job_status == "started":
-            progress = status.get("progress", 0)
             current_step = status.get("current_step", "Processing...")
-            st.info(f"**Status: {label}**")
-            if progress and progress > 0:
-                st.progress(progress, text=current_step or "Processing...")
+            st.info(f"**Status: {label}** - {current_step}")
 
         elif job_status == "finished":
             # Check if the job result indicates success or failure


### PR DESCRIPTION
## Summary
This PR removes progress bar visualizations from the queue monitoring and job status displays, simplifying the UI while retaining essential status information.

## Changes
- **src/common/common.py**: Removed worker utilization progress bar from `monitor_queue()` function
- **src/workflow/StreamlitUI.py**: 
  - Removed visual queue position progress indicator from `_show_queue_status()`
  - Removed job progress bar from the "started" status display
  - Consolidated job status info to display current step inline with status label

## Details
The progress bars were removed in favor of cleaner, text-based status indicators. Queue position and job progress information are still communicated to users through text labels, but without the visual progress components. This reduces UI clutter while maintaining transparency about job status and queue position.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the visual queue progress indicator in the queued state.
  * Updated the progress display in the started state to show the current step inline with the status, replacing the progress bar.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->