### PR TITLE
Add line limit filtering to workflow log display

### DIFF
--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -1188,13 +1188,19 @@ class StreamlitUI:
                 f"**Workflow log file: {datetime.fromtimestamp(log_path.stat().st_ctime).strftime('%Y-%m-%d %H:%M')} CET**"
             )
             with open(log_path, "r", encoding="utf-8") as f:
-                content = f.read()
+                lines = f.readlines()
+            content = "".join(lines)
             # Check if workflow finished successfully
             if "WORKFLOW FINISHED" in content:
                 st.success("**Workflow completed successfully.**")
             else:
                 st.error("**Errors occurred, check log file.**")
-            st.code(content, language="neon", line_numbers=False)
+            # Apply line limit to static display
+            if log_lines_count == "all":
+                display_lines = lines
+            else:
+                display_lines = lines[-st.session_state.log_lines_count:]
+            st.code("".join(display_lines), language="neon", line_numbers=False)
 
     def _show_queue_status(self, status: dict) -> None:
         """Display queue job status for online mode"""


### PR DESCRIPTION
## Summary
Enhanced the workflow log display in the execution section to support filtering log output based on a configurable line limit, while maintaining the full content for status checks.

## Key Changes
- Refactored log file reading from `read()` to `readlines()` for line-by-line processing
- Separated content parsing (for status checks) from display rendering
- Added conditional logic to apply line limit filtering:
  - When `log_lines_count == "all"`: display entire log
  - Otherwise: display only the last N lines based on `st.session_state.log_lines_count`
- Preserved original status detection logic that checks full content for "WORKFLOW FINISHED"

## Implementation Details
- The full log content is still read and checked for workflow completion status
- Only the display output is filtered, preventing loss of important status information
- Uses list slicing (`lines[-count:]`) for efficient tail-like behavior on large logs
- Maintains backward compatibility with existing "all" option for displaying complete logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added line-limiting display option for static logs, allowing you to view either all lines or only the last N lines based on your configuration.

* **Bug Fixes**
  * Improved log file reading and display handling for better reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->