### PR TITLE
Fix stderr logging level in CommandExecutor

### DIFF
--- a/src/workflow/CommandExecutor.py
+++ b/src/workflow/CommandExecutor.py
@@ -153,7 +153,7 @@ class CommandExecutor:
             try:
                 for line in iter(process.stderr.readline, ''):
                     if line:
-                        self.logger.log(f"STDERR: {line.rstrip()}", 2)
+                        self.logger.log(f"STDERR: {line.rstrip()}", 0)
                     if process.poll() is not None:
                         break
             except Exception as e:


### PR DESCRIPTION
## Summary
Changed the logging level for stderr output from level 2 to level 0 in the CommandExecutor's stderr reader.

## Changes
- Updated `CommandExecutor.read_stderr()` to log stderr messages at level 0 instead of level 2
- This ensures stderr output is captured with the correct logging priority

## Details
The stderr logging level has been adjusted from 2 to 0. This change likely addresses an issue where stderr messages were being logged at an inappropriate verbosity level, potentially causing them to be filtered out or not displayed with the correct priority depending on the logging configuration.

https://claude.ai/code/session_01L9vBwhCPsXUTTxen3sW8rn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error logging visibility during command execution to better capture and display system errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->