### PR TITLE
refactor: extract INI creation into shared ParameterManager.create_ini()

### DIFF
--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -641,12 +641,11 @@ class StreamlitUI:
 
         # write defaults ini files
         ini_file_path = Path(self.parameter_manager.ini_dir, f"{topp_tool_name}.ini")
-        if not ini_file_path.exists():
-            try:
-                subprocess.call([topp_tool_name, "-write_ini", str(ini_file_path)])
-            except FileNotFoundError:
-                st.error(f"TOPP tool **'{topp_tool_name}'** not found.")
-                return
+        ini_existed = ini_file_path.exists()
+        if not self.parameter_manager.create_ini(topp_tool_name):
+            st.error(f"TOPP tool **'{topp_tool_name}'** not found.")
+            return
+        if not ini_existed:
             # update custom defaults if necessary
             if custom_defaults:
                 param = poms.Param()


### PR DESCRIPTION
- Add create_ini() method to ParameterManager for creating TOPP tool ini files
- Update save_parameters() to use create_ini() instead of skipping missing ini files
- Update input_TOPP() in StreamlitUI to use the shared method
- Removes code duplication and enables ini creation during parameter save

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing TOPP tool configuration files; the system now automatically creates them when needed rather than failing.
  * Enhanced error handling for unavailable tools with clearer feedback when tools cannot be found.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->