### PR TITLE
Fix TOPP parameter handling for zero values

### DIFF
--- a/src/workflow/CommandExecutor.py
+++ b/src/workflow/CommandExecutor.py
@@ -236,7 +236,9 @@ class CommandExecutor:
             if tool in params.keys():
                 for k, v in params[tool].items():
                     command += [f"-{k}"]
-                    if v:  # Skip empty values (pass flag with no value)
+                    # Skip only empty strings (pass flag with no value)
+                    # Note: 0 and 0.0 are valid values, so use explicit check
+                    if v != "" and v is not None:
                         if isinstance(v, str) and "\n" in v:
                             command += v.split("\n")
                         else:
@@ -244,7 +246,9 @@ class CommandExecutor:
             # Add custom parameters
             for k, v in custom_params.items():
                 command += [f"-{k}"]
-                if v:
+                # Skip only empty strings (pass flag with no value)
+                # Note: 0 and 0.0 are valid values, so use explicit check
+                if v != "" and v is not None:
                     if isinstance(v, list):
                         command += [str(x) for x in v]
                     else:


### PR DESCRIPTION
Changed truthiness check `if v:` to explicit `if v != "" and v is not None:` to properly handle numeric zero values (0, 0.0) which are valid parameters.

Previously, setting fragment_bin_offset=0 would skip the value entirely, causing malformed command lines where the next flag was interpreted as the previous parameter's value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parameter handling to correctly process numeric zero values (0, 0.0) in command execution, while still properly filtering empty strings and None values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->