### PR TITLE
Add configurable thread limits for parallel command execution

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -26,5 +26,9 @@
         "source_dirs": [
             "example-data/workspaces"
         ]
+    },
+    "max_threads": {
+        "local": 4,
+        "online": 2
     }
 }

--- a/src/common/common.py
+++ b/src/common/common.py
@@ -32,6 +32,29 @@ from src.common.admin import (
 OS_PLATFORM = sys.platform
 
 
+def get_max_threads() -> int:
+    """
+    Get max threads for current deployment mode.
+
+    In local mode, checks for UI override in session state.
+    In online mode, uses the configured value directly.
+
+    Returns:
+        int: Maximum number of threads to use for parallel processing.
+    """
+    settings = st.session_state.get("settings", {})
+    max_threads_config = settings.get("max_threads", {"local": 4, "online": 2})
+
+    if settings.get("online_deployment", False):
+        return max_threads_config.get("online", 2)
+    else:
+        # Local mode: check for UI override, fallback to config default
+        return st.session_state.get(
+            "max_threads_override",
+            max_threads_config.get("local", 4)
+        )
+
+
 def is_safe_workspace_name(name: str) -> bool:
     """
     Check if a workspace name is safe (no path traversal characters).

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -1108,6 +1108,18 @@ class StreamlitUI:
     def parameter_section(self, custom_parameter_function) -> None:
         st.toggle("Show advanced parameters", value=False, key="advanced")
 
+        # Display threads configuration for local mode only
+        if not st.session_state.settings.get("online_deployment", False):
+            max_threads_config = st.session_state.settings.get("max_threads", {})
+            default_threads = max_threads_config.get("local", 4)
+            st.number_input(
+                "Threads",
+                min_value=1,
+                value=default_threads,
+                key="max_threads_override",
+                help="Maximum threads for parallel processing. Threads are distributed between parallel commands and per-tool thread allocation."
+            )
+
         # Display preset buttons if presets are available for this workflow
         self.preset_buttons()
 


### PR DESCRIPTION
## Summary
This PR introduces configurable thread limits for parallel command execution, allowing different thread allocations for local and online deployment modes. It includes a UI control for local mode users to override thread settings and distributes available threads between parallel command execution and per-tool thread allocation.

## Key Changes
- **Configuration**: Added `max_threads` settings to `settings.json` with separate limits for local (4 threads) and online (2 threads) modes
- **Common utility**: Implemented `get_max_threads()` function in `src/common/common.py` that respects deployment mode and UI overrides
- **Command execution**: Updated `CommandExecutor.run_multiple_commands()` to:
  - Use a semaphore to limit concurrent command execution based on `max_threads`
  - Calculate optimal thread distribution between parallel commands and per-tool allocation
  - Improve logging to show thread allocation details
- **TOPP tool execution**: Modified `run_topp()` to calculate and pass `threads_per_command` parameter to individual tools based on available threads
- **UI control**: Added a number input in `StreamlitUI.parameter_section()` for local mode users to override thread settings at runtime

## Implementation Details
- Thread distribution is calculated as: `threads_per_command = max_threads / parallel_commands`, ensuring efficient resource utilization
- Online mode uses configured limits directly without UI override capability
- Local mode allows runtime adjustment via session state, enabling users to optimize for their hardware
- The semaphore in `run_multiple_commands()` ensures the number of concurrent threads never exceeds the configured limit
- TOPP tools now receive explicit `-threads` parameter for better parallelization control

https://claude.ai/code/session_01XGuw7AxoKRWHr9EZX1SDXi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Configurable threading limits for command execution with deployment-specific defaults (4 threads for local, 2 for online)
  * Local mode now includes a thread count adjustment control in the interface
  * Automatic thread allocation optimization based on deployment environment

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->