### PR TITLE
fix: Windows executable build CAB file limit

### DIFF
--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -256,12 +256,6 @@ jobs:
         # Remove test directories
         Get-ChildItem -Path $sitePkgs -Recurse -Directory | Where-Object { $_.Name -match "^tests?$" } | Remove-Item -Recurse -Force
 
-        # Remove docs and examples
-        Get-ChildItem -Path $sitePkgs -Recurse -Directory | Where-Object { $_.Name -match "^(docs?|examples?)$" } | Remove-Item -Recurse -Force
-
-        # Remove .pyc and .pyo files
-        Get-ChildItem -Path $sitePkgs -Recurse -Include "*.pyc","*.pyo" | Remove-Item -Force
-
         # Count remaining files
         $count = (Get-ChildItem -Path $sitePkgs -Recurse -File).Count
         Write-Host "Remaining files in site-packages: $count"


### PR DESCRIPTION
Use MediaTemplate to automatically split files into multiple CAB archives and clean up unnecessary Python files (__pycache__, tests, docs) to reduce file count below the 65,535 CAB limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized the Windows executable build process by reducing package footprint through unnecessary file removal from the embedded Python environment.
  * Updated installer configuration to use an improved cabinet-based distribution method for better package handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->