### PR TITLE
Configure Streamlit to listen on all network interfaces (0.0.0.0)

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -5,6 +5,7 @@ gatherUsageStats = false
 developmentMode = false
 
 [server]
+address = "0.0.0.0"
 maxUploadSize =  200 #MB
 port = 8501 # should be same as configured in deployment repo
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -215,7 +215,7 @@ if [ "$SERVER_COUNT" -gt 1 ]; then\n\
 else\n\
     # Single instance mode (default) - run Streamlit directly on port 8501\n\
     echo "Starting Streamlit app..."\n\
-    exec streamlit run app.py\n\
+    exec streamlit run app.py --server.address 0.0.0.0\n\
 fi\n\
 ' > /app/entrypoint.sh
 # make the script executable

--- a/Dockerfile_simple
+++ b/Dockerfile_simple
@@ -112,7 +112,7 @@ if [ "$SERVER_COUNT" -gt 1 ]; then\n\
 \n\
     # Write nginx config\n\
     mkdir -p /etc/nginx\n\
-    echo -e "worker_processes auto;\\npid /run/nginx.pid;\\n\\nevents {\\n    worker_connections 1024;\\n}\\n\\nhttp {\\n    client_max_body_size 0;\\n\\n    map \\$cookie_stroute \\$route_key {\\n        \\x22\\x22      \\$request_id;\\n        default \\$cookie_stroute;\\n    }\\n\\n    upstream streamlit_backend {\\n        hash \\$route_key consistent;\\n${UPSTREAM_SERVERS}    }\\n\\n    map \\$http_upgrade \\$connection_upgrade {\\n        default upgrade;\\n        \\x27\\x27 close;\\n    }\\n\\n    server {\\n        listen 8501;\\n\\n        location / {\\n            proxy_pass http://streamlit_backend;\\n            proxy_http_version 1.1;\\n            proxy_set_header Upgrade \\$http_upgrade;\\n            proxy_set_header Connection \\$connection_upgrade;\\n            proxy_set_header Host \\$host;\\n            proxy_set_header X-Real-IP \\$remote_addr;\\n            proxy_set_header X-Forwarded-For \\$proxy_add_x_forwarded_for;\\n            proxy_set_header X-Forwarded-Proto \\$scheme;\\n            proxy_read_timeout 86400;\\n            proxy_send_timeout 86400;\\n            proxy_buffering off;\\n            add_header Set-Cookie \\x22stroute=\\$route_key; Path=/; HttpOnly; SameSite=Lax\\x22 always;\\n        }\\n    }\\n}" > /etc/nginx/nginx.conf\n\
+    echo -e "worker_processes auto;\\npid /run/nginx.pid;\\n\\nevents {\\n    worker_connections 1024;\\n}\\n\\nhttp {\\n    client_max_body_size 0;\\n\\n    map \\$cookie_stroute \\$route_key {\\n        \\x22\\x22      \\$request_id;\\n        default \\$cookie_stroute;\\n    }\\n\\n    upstream streamlit_backend {\\n        hash \\$route_key consistent;\\n${UPSTREAM_SERVERS}    }\\n\\n    map \\$http_upgrade \\$connection_upgrade {\\n        default upgrade;\\n        \\x27\\x27 close;\\n    }\\n\\n    server {\\n        listen 0.0.0.0:8501;\\n\\n        location / {\\n            proxy_pass http://streamlit_backend;\\n            proxy_http_version 1.1;\\n            proxy_set_header Upgrade \\$http_upgrade;\\n            proxy_set_header Connection \\$connection_upgrade;\\n            proxy_set_header Host \\$host;\\n            proxy_set_header X-Real-IP \\$remote_addr;\\n            proxy_set_header X-Forwarded-For \\$proxy_add_x_forwarded_for;\\n            proxy_set_header X-Forwarded-Proto \\$scheme;\\n            proxy_read_timeout 86400;\\n            proxy_send_timeout 86400;\\n            proxy_buffering off;\\n            add_header Set-Cookie \\x22stroute=\\$route_key; Path=/; HttpOnly; SameSite=Lax\\x22 always;\\n        }\\n    }\\n}" > /etc/nginx/nginx.conf\n\
 \n\
     # Start Streamlit instances on internal ports (localhost only)\n\
     for i in $(seq 0 $((SERVER_COUNT - 1))); do\n\
@@ -127,7 +127,7 @@ if [ "$SERVER_COUNT" -gt 1 ]; then\n\
 else\n\
     # Single instance mode (default) - run Streamlit directly on port 8501\n\
     echo "Starting Streamlit app..."\n\
-    exec streamlit run app.py\n\
+    exec streamlit run app.py --server.address 0.0.0.0\n\
 fi\n\
 ' > /app/entrypoint.sh
 # make the script executable


### PR DESCRIPTION
## Summary
This PR updates the Streamlit configuration to bind to all network interfaces (0.0.0.0) instead of the default localhost-only binding. This allows the application to be accessible from external hosts when deployed in containerized environments.

## Changes Made
- **`.streamlit/config.toml`**: Added `address = "0.0.0.0"` to the `[server]` configuration section
- **`Dockerfile`**: Updated the single-instance entrypoint to explicitly pass `--server.address 0.0.0.0` flag when starting Streamlit
- **`Dockerfile_simple`**: 
  - Updated the nginx configuration to listen on `0.0.0.0:8501` (changed from `8501`)
  - Updated the single-instance entrypoint to explicitly pass `--server.address 0.0.0.0` flag when starting Streamlit

## Implementation Details
The changes ensure consistent network binding across all deployment scenarios:
- The config file provides a default binding for local development
- The Docker entrypoint flags override/reinforce this setting for containerized deployments
- The nginx configuration in multi-instance mode now explicitly binds to all interfaces, making it accessible from outside the container
- Both single-instance and multi-instance deployment modes are updated for consistency

https://claude.ai/code/session_01GX2U6UAAj8sF1smN9Lc4J5