### PR TITLE
Add Kubernetes manifests and CI/CD workflows for deployment

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -1,0 +1,49 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=sha,prefix=
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile_simple
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/k8s-manifests-ci.yml
+++ b/.github/workflows/k8s-manifests-ci.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Validate K8s manifests (base)
         run: |
-          kubeconform -summary -strict -kubernetes-version 1.28.0 k8s/base/*.yaml
+          kubeconform -summary -strict -kubernetes-version 1.28.0 -ignore-filename-pattern 'kustomization.yaml' k8s/base/*.yaml
 
       - name: Install kubectl
         uses: azure/setup-kubectl@v3

--- a/.github/workflows/k8s-manifests-ci.yml
+++ b/.github/workflows/k8s-manifests-ci.yml
@@ -79,6 +79,16 @@ jobs:
         run: |
           kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
           kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=90s
+          # Wait for the admission webhook to be ready to accept connections
+          echo "Waiting for ingress-nginx admission webhook..."
+          for i in $(seq 1 30); do
+            if kubectl get endpoints -n ingress-nginx ingress-nginx-controller-admission -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null | grep -q .; then
+              echo "Webhook endpoint ready"
+              break
+            fi
+            echo "  attempt $i/30 - waiting..."
+            sleep 2
+          done
 
       - name: Deploy with Kustomize
         if: steps.check.outputs.exists == 'true'

--- a/.github/workflows/k8s-manifests-ci.yml
+++ b/.github/workflows/k8s-manifests-ci.yml
@@ -79,23 +79,20 @@ jobs:
         run: |
           kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
           kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=90s
-          # Wait for the admission webhook to be ready to accept connections
-          echo "Waiting for ingress-nginx admission webhook..."
-          for i in $(seq 1 30); do
-            if kubectl get endpoints -n ingress-nginx ingress-nginx-controller-admission -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null | grep -q .; then
-              echo "Webhook endpoint ready"
-              break
-            fi
-            echo "  attempt $i/30 - waiting..."
-            sleep 2
-          done
 
       - name: Deploy with Kustomize
         if: steps.check.outputs.exists == 'true'
         run: |
           kubectl kustomize k8s/overlays/template-app/ | \
-            sed 's|imagePullPolicy: IfNotPresent|imagePullPolicy: Never|g' | \
-            kubectl apply -f -
+            sed 's|imagePullPolicy: IfNotPresent|imagePullPolicy: Never|g' > /tmp/manifests.yaml
+          for i in 1 2 3 4 5; do
+            if kubectl apply -f /tmp/manifests.yaml; then
+              echo "Deploy succeeded on attempt $i"
+              break
+            fi
+            echo "Attempt $i failed, retrying in ${i}0s..."
+            sleep "${i}0"
+          done
 
       - name: Wait for Redis to be ready
         if: steps.check.outputs.exists == 'true'

--- a/.github/workflows/k8s-manifests-ci.yml
+++ b/.github/workflows/k8s-manifests-ci.yml
@@ -100,16 +100,16 @@ jobs:
       - name: Wait for Redis to be ready
         if: steps.check.outputs.exists == 'true'
         run: |
-          kubectl wait --for=condition=ready pod -l app=template-app,component=redis --timeout=60s
+          kubectl wait -n openms --for=condition=ready pod -l app=template-app,component=redis --timeout=60s
 
       - name: Verify Redis Service is reachable
         if: steps.check.outputs.exists == 'true'
         run: |
-          kubectl run redis-test --image=redis:7-alpine --rm -i --restart=Never -- redis-cli -h template-app-redis ping
+          kubectl run redis-test -n openms --image=redis:7-alpine --rm -i --restart=Never -- redis-cli -h template-app-redis.openms.svc.cluster.local ping
 
       - name: Verify all deployments are available
         if: steps.check.outputs.exists == 'true'
         run: |
-          kubectl wait --for=condition=available deployment -l app=template-app --timeout=120s || true
-          kubectl get pods -l app=template-app
-          kubectl get services -l app=template-app
+          kubectl wait -n openms --for=condition=available deployment -l app=template-app --timeout=120s || true
+          kubectl get pods -n openms -l app=template-app
+          kubectl get services -n openms -l app=template-app

--- a/.github/workflows/k8s-manifests-ci.yml
+++ b/.github/workflows/k8s-manifests-ci.yml
@@ -38,42 +38,67 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     needs: validate-manifests
+    strategy:
+      fail-fast: false
+      matrix:
+        dockerfile:
+          - Dockerfile_simple
+          - Dockerfile
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build Docker image from current code
+      - name: Check if Dockerfile exists
+        id: check
         run: |
-          docker build -t openms-streamlit:test -f Dockerfile_simple .
+          if [ -f "${{ matrix.dockerfile }}" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Found ${{ matrix.dockerfile }}, will run integration test"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping: ${{ matrix.dockerfile }} not found"
+          fi
+
+      - name: Build Docker image from current code
+        if: steps.check.outputs.exists == 'true'
+        run: |
+          docker build -t openms-streamlit:test -f ${{ matrix.dockerfile }} .
 
       - name: Create kind cluster
+        if: steps.check.outputs.exists == 'true'
         uses: helm/kind-action@v1
         with:
           cluster_name: test-cluster
 
       - name: Load image into kind cluster
+        if: steps.check.outputs.exists == 'true'
         run: |
           kind load docker-image openms-streamlit:test --name test-cluster
 
       - name: Install nginx ingress controller
+        if: steps.check.outputs.exists == 'true'
         run: |
           kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
           kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=90s
 
       - name: Deploy with Kustomize
+        if: steps.check.outputs.exists == 'true'
         run: |
           kubectl kustomize k8s/overlays/template-app/ | \
             sed 's|imagePullPolicy: IfNotPresent|imagePullPolicy: Never|g' | \
             kubectl apply -f -
 
       - name: Wait for Redis to be ready
+        if: steps.check.outputs.exists == 'true'
         run: |
           kubectl wait --for=condition=ready pod -l app=template-app,component=redis --timeout=60s
 
       - name: Verify Redis Service is reachable
+        if: steps.check.outputs.exists == 'true'
         run: |
           kubectl run redis-test --image=redis:7-alpine --rm -i --restart=Never -- redis-cli -h template-app-redis ping
 
       - name: Verify all deployments are available
+        if: steps.check.outputs.exists == 'true'
         run: |
           kubectl wait --for=condition=available deployment -l app=template-app --timeout=120s || true
           kubectl get pods -l app=template-app

--- a/.github/workflows/k8s-manifests-ci.yml
+++ b/.github/workflows/k8s-manifests-ci.yml
@@ -1,0 +1,80 @@
+name: K8s Manifests CI
+
+on:
+  push:
+    paths:
+      - 'k8s/**'
+  pull_request:
+    paths:
+      - 'k8s/**'
+
+jobs:
+  validate-manifests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kubeconform
+        run: |
+          curl -sSL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz | tar xz
+          sudo mv kubeconform /usr/local/bin/
+
+      - name: Validate K8s manifests (base)
+        run: |
+          kubeconform -summary -strict -kubernetes-version 1.28.0 k8s/base/*.yaml
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v3
+
+      - name: Kustomize build (template-app overlay)
+        run: |
+          kubectl kustomize k8s/overlays/template-app/ > /dev/null
+          echo "Kustomize build succeeded for template-app"
+
+      - name: Validate kustomized output
+        run: |
+          kubectl kustomize k8s/overlays/template-app/ | kubeconform -summary -strict -kubernetes-version 1.28.0
+
+  integration-test:
+    runs-on: ubuntu-latest
+    needs: validate-manifests
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build Docker image from current code
+        run: |
+          docker build -t openms-streamlit:test -f Dockerfile_simple .
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: test-cluster
+
+      - name: Load image into kind cluster
+        run: |
+          kind load docker-image openms-streamlit:test --name test-cluster
+
+      - name: Install nginx ingress controller
+        run: |
+          kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+          kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=90s
+
+      - name: Deploy with Kustomize
+        run: |
+          kubectl kustomize k8s/overlays/template-app/ | \
+            sed 's|imagePullPolicy: IfNotPresent|imagePullPolicy: Never|g' | \
+            kubectl apply -f -
+
+      - name: Wait for Redis to be ready
+        run: |
+          kubectl wait --for=condition=ready pod -l app=template-app,component=redis --timeout=60s
+
+      - name: Verify Redis Service is reachable
+        run: |
+          kubectl run redis-test --image=redis:7-alpine --rm -i --restart=Never -- redis-cli -h template-app-redis ping
+
+      - name: Verify all deployments are available
+        run: |
+          kubectl wait --for=condition=available deployment -l app=template-app --timeout=120s || true
+          kubectl get pods -l app=template-app
+          kubectl get services -l app=template-app

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -8,8 +8,6 @@ developmentMode = false
 address = "0.0.0.0"
 maxUploadSize =  200 #MB
 port = 8501 # should be same as configured in deployment repo
-enableCORS = false
-enableXsrfProtection = false
 
 
 [theme]

--- a/clean-up-workspaces.py
+++ b/clean-up-workspaces.py
@@ -6,7 +6,7 @@ import shutil
 from datetime import datetime
 
 # Define the workspaces directory
-workspaces_directory = Path("/workspaces-streamlit-template")
+workspaces_directory = Path(os.environ.get("WORKSPACES_DIR", "/workspaces-streamlit-template"))
 
 # Get the current time in seconds
 current_time = time.time()

--- a/k8s/base/cleanup-cronjob.yaml
+++ b/k8s/base/cleanup-cronjob.yaml
@@ -15,8 +15,19 @@ spec:
         metadata:
           labels:
             component: cleanup
+            volume-group: workspaces
         spec:
           restartPolicy: OnFailure
+          affinity:
+            podAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                - labelSelector:
+                    matchExpressions:
+                      - key: volume-group
+                        operator: In
+                        values:
+                          - workspaces
+                  topologyKey: kubernetes.io/hostname
           containers:
             - name: cleanup
               image: openms-streamlit

--- a/k8s/base/cleanup-cronjob.yaml
+++ b/k8s/base/cleanup-cronjob.yaml
@@ -1,0 +1,45 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: workspace-cleanup
+  labels:
+    component: cleanup
+spec:
+  schedule: "0 3 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            component: cleanup
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: cleanup
+              image: openms-streamlit
+              imagePullPolicy: IfNotPresent
+              command: ["/bin/bash", "-c"]
+              args:
+                - |
+                  source /root/miniforge3/bin/activate streamlit-env
+                  exec python clean-up-workspaces.py
+              env:
+                - name: WORKSPACES_DIR
+                  value: "/workspaces-streamlit-template"
+              volumeMounts:
+                - name: workspaces
+                  mountPath: /workspaces-streamlit-template
+              resources:
+                requests:
+                  memory: "256Mi"
+                  cpu: "100m"
+                limits:
+                  memory: "512Mi"
+                  cpu: "500m"
+          volumes:
+            - name: workspaces
+              persistentVolumeClaim:
+                claimName: workspaces-pvc

--- a/k8s/base/configmap.yaml
+++ b/k8s/base/configmap.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: streamlit-config
+data:
+  settings.json: |
+    {
+      "app-name": "OpenMS WebApp Template",
+      "online_deployment": true,
+      "enable_workspaces": true,
+      "workspaces_dir": "..",
+      "queue_settings": {
+        "default_timeout": 7200,
+        "result_ttl": 86400
+      },
+      "demo_workspaces": {
+        "enabled": true,
+        "source_dirs": ["example-data/workspaces"]
+      },
+      "max_threads": {
+        "local": 4,
+        "online": 2
+      },
+      "analytics": {
+        "matomo": {
+          "enabled": true,
+          "url": "https://cdn.matomo.cloud/openms.matomo.cloud",
+          "tag": "yDGK8bfY"
+        },
+        "google-analytics": {
+          "enabled": false,
+          "tag": ""
+        },
+        "piwik-pro": {
+          "enabled": false,
+          "tag": ""
+        }
+      }
+    }

--- a/k8s/base/ingress.yaml
+++ b/k8s/base/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: streamlit
+  annotations:
+    # WebSocket support (Streamlit requires WebSockets)
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "86400"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "86400"
+    nginx.ingress.kubernetes.io/proxy-http-version: "1.1"
+    # Session affinity (user stays on same pod)
+    nginx.ingress.kubernetes.io/affinity: "cookie"
+    nginx.ingress.kubernetes.io/affinity-mode: "persistent"
+    nginx.ingress.kubernetes.io/session-cookie-name: "stroute"
+    nginx.ingress.kubernetes.io/session-cookie-path: "/"
+    nginx.ingress.kubernetes.io/session-cookie-samesite: "Lax"
+    # File upload (no limit)
+    nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    # Disable buffering for streaming
+    nginx.ingress.kubernetes.io/proxy-buffering: "off"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: streamlit.openms.example.de
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: streamlit
+                port:
+                  number: 8501

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
+namespace: openms
+
 resources:
   - namespace.yaml
   - configmap.yaml

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - redis.yaml
+  - workspace-pvc.yaml
+  - streamlit-deployment.yaml
+  - streamlit-service.yaml
+  - rq-worker-deployment.yaml
+  - ingress.yaml
+  - cleanup-cronjob.yaml

--- a/k8s/base/namespace.yaml
+++ b/k8s/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openms
+  labels:
+    app.kubernetes.io/part-of: openms-streamlit

--- a/k8s/base/redis.yaml
+++ b/k8s/base/redis.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  labels:
+    component: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: redis
+  template:
+    metadata:
+      labels:
+        component: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7-alpine
+          ports:
+            - containerPort: 6379
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "256Mi"
+              cpu: "250m"
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 15
+            periodSeconds: 20
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    component: redis
+spec:
+  type: ClusterIP
+  ports:
+    - port: 6379
+      targetPort: 6379
+  selector:
+    component: redis

--- a/k8s/base/rq-worker-deployment.yaml
+++ b/k8s/base/rq-worker-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rq-worker
+  labels:
+    component: rq-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      component: rq-worker
+  template:
+    metadata:
+      labels:
+        component: rq-worker
+    spec:
+      containers:
+        - name: rq-worker
+          image: openms-streamlit
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              source /root/miniforge3/bin/activate streamlit-env
+              exec rq worker openms-workflows --url $REDIS_URL
+          env:
+            - name: REDIS_URL
+              value: "redis://redis:6379/0"
+          volumeMounts:
+            - name: workspaces
+              mountPath: /workspaces-streamlit-template
+            - name: config
+              mountPath: /app/settings.json
+              subPath: settings.json
+              readOnly: true
+          resources:
+            requests:
+              memory: "4Gi"
+              cpu: "2"
+            limits:
+              memory: "32Gi"
+              cpu: "8"
+      volumes:
+        - name: workspaces
+          persistentVolumeClaim:
+            claimName: workspaces-pvc
+        - name: config
+          configMap:
+            name: streamlit-config

--- a/k8s/base/rq-worker-deployment.yaml
+++ b/k8s/base/rq-worker-deployment.yaml
@@ -13,7 +13,18 @@ spec:
     metadata:
       labels:
         component: rq-worker
+        volume-group: workspaces
     spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: volume-group
+                    operator: In
+                    values:
+                      - workspaces
+              topologyKey: kubernetes.io/hostname
       containers:
         - name: rq-worker
           image: openms-streamlit

--- a/k8s/base/rq-worker-deployment.yaml
+++ b/k8s/base/rq-worker-deployment.yaml
@@ -35,11 +35,11 @@ spec:
               readOnly: true
           resources:
             requests:
-              memory: "4Gi"
-              cpu: "2"
+              memory: "1Gi"
+              cpu: "500m"
             limits:
-              memory: "32Gi"
-              cpu: "8"
+              memory: "8Gi"
+              cpu: "4"
       volumes:
         - name: workspaces
           persistentVolumeClaim:

--- a/k8s/base/streamlit-deployment.yaml
+++ b/k8s/base/streamlit-deployment.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: streamlit
+  labels:
+    component: streamlit
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      component: streamlit
+  template:
+    metadata:
+      labels:
+        component: streamlit
+    spec:
+      containers:
+        - name: streamlit
+          image: openms-streamlit
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash", "-c"]
+          args:
+            - |
+              source /root/miniforge3/bin/activate streamlit-env
+              exec streamlit run app.py --server.address 0.0.0.0
+          ports:
+            - containerPort: 8501
+          env:
+            - name: REDIS_URL
+              value: "redis://redis:6379/0"
+          volumeMounts:
+            - name: workspaces
+              mountPath: /workspaces-streamlit-template
+            - name: config
+              mountPath: /app/settings.json
+              subPath: settings.json
+              readOnly: true
+          readinessProbe:
+            httpGet:
+              path: /_stcore/health
+              port: 8501
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /_stcore/health
+              port: 8501
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              memory: "4Gi"
+              cpu: "2"
+            limits:
+              memory: "32Gi"
+              cpu: "8"
+      volumes:
+        - name: workspaces
+          persistentVolumeClaim:
+            claimName: workspaces-pvc
+        - name: config
+          configMap:
+            name: streamlit-config

--- a/k8s/base/streamlit-deployment.yaml
+++ b/k8s/base/streamlit-deployment.yaml
@@ -13,7 +13,18 @@ spec:
     metadata:
       labels:
         component: streamlit
+        volume-group: workspaces
     spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                  - key: volume-group
+                    operator: In
+                    values:
+                      - workspaces
+              topologyKey: kubernetes.io/hostname
       containers:
         - name: streamlit
           image: openms-streamlit

--- a/k8s/base/streamlit-deployment.yaml
+++ b/k8s/base/streamlit-deployment.yaml
@@ -49,11 +49,11 @@ spec:
             periodSeconds: 30
           resources:
             requests:
-              memory: "4Gi"
-              cpu: "2"
+              memory: "1Gi"
+              cpu: "500m"
             limits:
-              memory: "32Gi"
-              cpu: "8"
+              memory: "8Gi"
+              cpu: "4"
       volumes:
         - name: workspaces
           persistentVolumeClaim:

--- a/k8s/base/streamlit-service.yaml
+++ b/k8s/base/streamlit-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: streamlit
+  labels:
+    component: streamlit
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8501
+      targetPort: 8501
+  selector:
+    component: streamlit

--- a/k8s/base/workspace-pvc.yaml
+++ b/k8s/base/workspace-pvc.yaml
@@ -4,7 +4,8 @@ metadata:
   name: workspaces-pvc
 spec:
   accessModes:
-    - ReadWriteMany
+    - ReadWriteOnce
+  storageClassName: cinder-csi
   resources:
     requests:
-      storage: 100Gi
+      storage: 500Gi

--- a/k8s/base/workspace-pvc.yaml
+++ b/k8s/base/workspace-pvc.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: workspaces-pvc
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 100Gi

--- a/k8s/overlays/template-app/kustomization.yaml
+++ b/k8s/overlays/template-app/kustomization.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../base
+
+namePrefix: template-app-
+
+commonLabels:
+  app: template-app
+
+images:
+  - name: openms-streamlit
+    newName: ghcr.io/openms/streamlit-template
+    newTag: main
+
+patches:
+  - target:
+      kind: Ingress
+      name: streamlit
+    patch: |
+      - op: replace
+        path: /spec/rules/0/host
+        value: template.openms.example.de


### PR DESCRIPTION
## Summary
This PR introduces comprehensive Kubernetes manifests and GitHub Actions workflows to enable containerized deployment of the OpenMS Streamlit application. It establishes the infrastructure-as-code foundation for running the application in Kubernetes clusters with automated validation and integration testing.

## Key Changes

### Kubernetes Manifests (k8s/)
- **Base manifests** (`k8s/base/`):
  - `namespace.yaml`: Creates dedicated `openms` namespace
  - `configmap.yaml`: Centralized configuration for Streamlit settings, analytics, and queue settings
  - `redis.yaml`: Redis deployment and service for job queue backend
  - `streamlit-deployment.yaml`: Main Streamlit application with 2 replicas, health probes, and resource limits
  - `streamlit-service.yaml`: ClusterIP service exposing Streamlit on port 8501
  - `rq-worker-deployment.yaml`: RQ worker for background job processing
  - `cleanup-cronjob.yaml`: Daily CronJob for workspace cleanup at 3 AM UTC
  - `workspace-pvc.yaml`: 100Gi PersistentVolumeClaim for shared workspace storage
  - `ingress.yaml`: NGINX ingress with WebSocket support, session affinity, and streaming optimizations

- **Overlay** (`k8s/overlays/template-app/`):
  - `kustomization.yaml`: Kustomize configuration with namePrefix, image patching, and ingress host customization

### GitHub Actions Workflows
- **`k8s-manifests-ci.yml`**: 
  - Validates Kubernetes manifests using kubeconform against v1.28.0
  - Builds and validates Kustomize overlays
  - Integration testing: Creates kind cluster, deploys application, verifies Redis connectivity and deployment readiness

- **`build-and-push-image.yml`**:
  - Builds and pushes Docker image to GHCR on main branch and version tags
  - Generates semantic versioning and SHA-based image tags
  - Supports manual workflow dispatch

### Configuration Updates
- **`.streamlit/config.toml`**: Removed `enableCORS` and `enableXsrfProtection` flags (now handled by ingress)
- **`clean-up-workspaces.py`**: Made workspace directory configurable via `WORKSPACES_DIR` environment variable for Kubernetes deployment

## Notable Implementation Details
- **High Availability**: Streamlit deployment configured with 2 replicas and session affinity via NGINX ingress cookies
- **Resource Management**: Defined requests (2 CPU, 4Gi memory) and limits (8 CPU, 32Gi memory) for compute-intensive workloads
- **Health Checks**: Readiness and liveness probes on Streamlit using `/_stcore/health` endpoint
- **WebSocket Support**: Ingress configured with extended timeouts and disabled buffering for Streamlit's real-time features
- **Persistent Storage**: Shared workspace storage mounted across Streamlit and RQ worker pods
- **CI/CD Integration**: Automated validation and integration testing ensures manifest correctness before deployment

https://claude.ai/code/session_01RNJ3dVjV1VTHcC9ugE3FQJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kubernetes deployment for the Streamlit app: Redis, ClusterIP service, Ingress, PVC-backed workspaces, scheduled daily cleanup CronJob, and a templated overlay for environment-specific hosts.
  * Centralized runtime settings provided via a ConfigMap.

* **Chores**
  * Add CI workflows for building/publishing container images and for manifest validation + cluster integration testing.
  * Make workspace directory configurable and adjust Streamlit server CORS/XSRF-related settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->