### PR TITLE
fix: correctly parse and route implicit boolean flags from ini files (#90)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,6 +26,7 @@ contourpy==1.3.1
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
+defusedxml==0.7.1
 fonttools==4.59.2
     # via matplotlib
 gitdb==4.0.12

--- a/src/workflow/CommandExecutor.py
+++ b/src/workflow/CommandExecutor.py
@@ -263,6 +263,10 @@ class CommandExecutor:
 
         # Load parameters for non-defaults
         params = self.parameter_manager.get_parameters_from_json()
+
+        # NEW LOGIC: Ask the ParameterManager which keys are strictly booleans
+        bool_params = self.parameter_manager.get_boolean_parameters(tool)
+
         # Construct commands for each process
         for i in range(n_processes):
             command = [tool]
@@ -281,27 +285,38 @@ class CommandExecutor:
                 # standard case, files was a list of strings, take the file name at index
                 else:
                     command += [value[i]]
+
             # Add non-default TOPP tool parameters
             if tool in params.keys():
                 for k, v in params[tool].items():
-                    command += [f"-{k}"]
-                    # Skip only empty strings (pass flag with no value)
-                    # Note: 0 and 0.0 are valid values, so use explicit check
-                    if v != "" and v is not None:
-                        if isinstance(v, str) and "\n" in v:
-                            command += v.split("\n")
-                        else:
-                            command += [str(v)]
+                    # NEW LOGIC: Intercept boolean flags
+                    if k in bool_params:
+                        # Only add the implicit flag if True. If False, omit entirely.
+                        if str(v).lower() == "true":
+                            command += [f"-{k}"]
+                    else:
+                        # Existing logic for strings, ints, floats
+                        command += [f"-{k}"]
+                        if v != "" and v is not None:
+                            if isinstance(v, str) and "\n" in v:
+                                command += v.split("\n")
+                            else:
+                                command += [str(v)]
+
             # Add custom parameters
             for k, v in custom_params.items():
-                command += [f"-{k}"]
-                # Skip only empty strings (pass flag with no value)
-                # Note: 0 and 0.0 are valid values, so use explicit check
-                if v != "" and v is not None:
-                    if isinstance(v, list):
-                        command += [str(x) for x in v]
-                    else:
-                        command += [str(v)]
+                # NEW LOGIC: Intercept custom boolean flags
+                if k in bool_params:
+                    if str(v).lower() == "true":
+                        command += [f"-{k}"]
+                else:
+                    command += [f"-{k}"]
+                    if v != "" and v is not None:
+                        if isinstance(v, list):
+                            command += [str(x) for x in v]
+                        else:
+                            command += [str(v)]
+
             # Add threads parameter for TOPP tools
             command += ["-threads", str(threads_per_command)]
             commands.append(command)

--- a/src/workflow/ParameterManager.py
+++ b/src/workflow/ParameterManager.py
@@ -299,7 +299,8 @@ class ParameterManager:
             tool: Name of the TOPP tool (e.g., "FeatureFinderMetabo")
 
         Returns:
-            list: A list of parameter names (strings) that are strictly booleans.
+            list: A list of parameter names (strings) that are strictly booleans, 
+                  including their full hierarchical paths (e.g., 'algorithm:epd:masstrace_snr_filtering').
         """
         # SELF-HEALING FIX: Force generate the .ini file if it doesn't exist yet
         if not self.create_ini(tool):
@@ -311,12 +312,34 @@ class ParameterManager:
         try:
             tree = ET.parse(ini_path)
             root = tree.getroot()
-            # Recursively find all ITEM tags in the XML tree with type="bool"
-            for item in root.findall(".//ITEM[@type='bool']"):
-                name = item.get("name")
-                if name:
-                    bool_params.append(name)
-        except Exception:
-            pass  # Safely return empty list if XML parsing fails
 
-        return bool_params
+            # Recursive function to build the hierarchical path from XML nodes
+            def traverse(node, current_path):
+                for child in node:
+                    if child.tag == "ITEM" and child.get("type") == "bool":
+                        name = child.get("name")
+                        if name:
+                            bool_params.append(current_path + name)
+                    elif child.tag == "NODE":
+                        name = child.get("name")
+                        if name:
+                            # Append the node name and a colon to the path
+                            traverse(child, current_path + name + ":")
+
+            # Start traversal from the XML root
+            traverse(root, "")
+
+            # OpenMS INI files usually encapsulate everything in a top-level <NODE name="ToolName">.
+            # We must strip this prefix so the keys perfectly match the JSON session state keys.
+            tool_prefix = f"{tool}:"
+            cleaned_params = [
+                p[len(tool_prefix):] if p.startswith(tool_prefix) else p 
+                for p in bool_params
+            ]
+
+            return cleaned_params
+
+        except Exception:
+            pass # Safely return empty list if XML parsing fails
+
+        return []

--- a/src/workflow/ParameterManager.py
+++ b/src/workflow/ParameterManager.py
@@ -3,7 +3,7 @@ import json
 import shutil
 import subprocess
 import streamlit as st
-import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as ET
 from pathlib import Path
 
 class ParameterManager:
@@ -292,24 +292,32 @@ class ParameterManager:
 
     def get_boolean_parameters(self, tool: str) -> list:
         """
-        Parses the tool's .ini XML file to find all parameters explicitly defined as type 'bool'.
-        This bypasses the pyOpenMS internal mapping which loses the boolean type definition.
+        Parses the tool's generated .ini (XML) file to discover strictly boolean parameters.
+        This prevents implicit booleans from being passed as strings to the command line.
 
         Args:
-            tool: Name of the TOPP tool (e.g., "FeatureFinderMetabo")
+            tool (str): The name of the TOPP tool (e.g., 'FeatureFinderMetabo').
 
         Returns:
-            list: A list of parameter names (strings) that are strictly booleans, 
-                  including their full hierarchical paths (e.g., 'algorithm:epd:masstrace_snr_filtering').
+            list: A list of hierarchical parameter keys that are explicitly typed as 'bool'.
+
+        Raises:
+            FileNotFoundError: If the .ini file does not exist.
+            RuntimeError: If the .ini file fails to generate.
+            ET.ParseError: If the XML parsing fails.
         """
-        # SELF-HEALING FIX: Force generate the .ini file if it doesn't exist yet
         if not self.create_ini(tool):
-            return []
+            # CodeRabbit Fix: Raise an explicit error instead of silently returning []
+            raise RuntimeError(f"Failed to generate .ini file for TOPP tool: {tool}")
 
         ini_path = Path(self.ini_dir, f"{tool}.ini")
+        if not ini_path.exists():
+            # CodeRabbit Fix: Raise an explicit error instead of silently returning []
+            raise FileNotFoundError(f"Missing expected .ini file for TOPP tool at: {ini_path}")
 
         bool_params = []
         try:
+            # CodeRabbit Fix: Use defusedxml (imported as ET) to safely parse the file
             tree = ET.parse(ini_path)
             root = tree.getroot()
 
@@ -339,7 +347,8 @@ class ParameterManager:
 
             return cleaned_params
 
-        except Exception as e:
+        except ET.ParseError as e: 
+            logger.error(f"XML parsing failed for {tool}: {e}"); raise
             print(f"Error parsing boolean parameters for {tool}: {e}")
             pass # Safely return empty list if XML parsing fails
         return []

--- a/src/workflow/ParameterManager.py
+++ b/src/workflow/ParameterManager.py
@@ -331,7 +331,7 @@ class ParameterManager:
 
             # OpenMS INI files usually encapsulate everything in a top-level <NODE name="ToolName">.
             # We must strip this prefix so the keys perfectly match the JSON session state keys.
-            tool_prefix = f"{tool}:"
+            tool_prefix = f"{tool}:1:"
             cleaned_params = [
                 p[len(tool_prefix):] if p.startswith(tool_prefix) else p 
                 for p in bool_params
@@ -339,7 +339,7 @@ class ParameterManager:
 
             return cleaned_params
 
-        except Exception:
+        except Exception as e:
+            print(f"Error parsing boolean parameters for {tool}: {e}")
             pass # Safely return empty list if XML parsing fails
-
         return []

--- a/src/workflow/ParameterManager.py
+++ b/src/workflow/ParameterManager.py
@@ -301,9 +301,11 @@ class ParameterManager:
         Returns:
             list: A list of parameter names (strings) that are strictly booleans.
         """
-        ini_path = Path(self.ini_dir, f"{tool}.ini")
-        if not ini_path.exists():
+        # SELF-HEALING FIX: Force generate the .ini file if it doesn't exist yet
+        if not self.create_ini(tool):
             return []
+
+        ini_path = Path(self.ini_dir, f"{tool}.ini")
 
         bool_params = []
         try:

--- a/src/workflow/ParameterManager.py
+++ b/src/workflow/ParameterManager.py
@@ -347,8 +347,9 @@ class ParameterManager:
 
             return cleaned_params
 
-        except ET.ParseError as e: 
-            logger.error(f"XML parsing failed for {tool}: {e}"); raise
+        except ET.ParseError as e:
+            st.error(f"XML parsing failed for {tool}: {e}")
+            raise
             print(f"Error parsing boolean parameters for {tool}: {e}")
             pass # Safely return empty list if XML parsing fails
         return []

--- a/src/workflow/ParameterManager.py
+++ b/src/workflow/ParameterManager.py
@@ -3,6 +3,7 @@ import json
 import shutil
 import subprocess
 import streamlit as st
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 class ParameterManager:
@@ -288,3 +289,32 @@ class ParameterManager:
         ]
         for key in keys_to_delete:
             del st.session_state[key]
+
+    def get_boolean_parameters(self, tool: str) -> list:
+        """
+        Parses the tool's .ini XML file to find all parameters explicitly defined as type 'bool'.
+        This bypasses the pyOpenMS internal mapping which loses the boolean type definition.
+
+        Args:
+            tool: Name of the TOPP tool (e.g., "FeatureFinderMetabo")
+
+        Returns:
+            list: A list of parameter names (strings) that are strictly booleans.
+        """
+        ini_path = Path(self.ini_dir, f"{tool}.ini")
+        if not ini_path.exists():
+            return []
+
+        bool_params = []
+        try:
+            tree = ET.parse(ini_path)
+            root = tree.getroot()
+            # Recursively find all ITEM tags in the XML tree with type="bool"
+            for item in root.findall(".//ITEM[@type='bool']"):
+                name = item.get("name")
+                if name:
+                    bool_params.append(name)
+        except Exception:
+            pass  # Safely return empty list if XML parsing fails
+
+        return bool_params


### PR DESCRIPTION
Fixes #90.

Hi @t0mdavid-m! I am currently preparing my GSoC 2026 proposal for Project C1 and wanted to tackle this stalled issue to get familiar with the parameter routing architecture.

As discussed in the original issue thread, the previous PR (#176) hit a roadblock because the internal C++ pyOpenMS wrapper maps both booleans and strings to STRING_VALUE, making them indistinguishable at runtime. I have implemented your exact suggested solution to bypass this by inspecting the generated .ini files directly.

Changes made:

ParameterManager.py: Added a new get_boolean_parameters() method. This uses Python's built-in xml.etree.ElementTree to parse the tool's .ini file and extract a strict list of parameters explicitly defined as type="bool".

CommandExecutor.py: Updated run_topp() to query the ParameterManager for boolean keys before constructing the command. If a key is a confirmed boolean, it applies implicit routing: appending -flag if True, and omitting it entirely if False. Standard explicit routing is preserved for strings and numeric values.

Tested locally using the standard TOPP workflow. FeatureFinderMetabo now correctly omits the masstrace_snr_filtering flag when set to false, preventing the Trailing text argument(s) '[false]' given crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Boolean parameters now emit flags only when true, preventing false flags.
  * Multi-line string parameter values are handled correctly.
  * Custom parameters accept list values and respect boolean flag semantics.
  * Existing handling for non-boolean, empty, or null parameters preserved.

* **New Features**
  * Added a way to discover which parameters are boolean for each tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->