### PR TITLE
Upgrade Docker build workflow to use buildx with caching

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -13,15 +13,33 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: Build the full Docker image
-      run: docker build . --file Dockerfile --tag streamlitapp:latest
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: Dockerfile
+        tags: streamlitapp:latest
+        load: true
+        cache-from: type=gha,scope=full-app
+        cache-to: type=gha,mode=max,scope=full-app
 
   build-simple-app:
 
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: Build the Docker image (pyOpenMS only)
-      run: docker build . --file Dockerfile_simple --tag streamlitapp-simple:latest
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: Dockerfile_simple
+        tags: streamlitapp-simple:latest
+        load: true
+        cache-from: type=gha,scope=simple-app
+        cache-to: type=gha,mode=max,scope=simple-app

--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-import streamlit as st
+import streamlit as st  # cache test
 from pathlib import Path
 import json
 # For some reason the windows version only works if this is imported here

--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-import streamlit as st  # cache test
+import streamlit as st
 from pathlib import Path
 import json
 # For some reason the windows version only works if this is imported here


### PR DESCRIPTION
## Summary
Upgraded the Docker image build workflow to use Docker Buildx with GitHub Actions caching for improved build performance and consistency.

## Key Changes
- Updated `actions/checkout` from v3 to v4
- Replaced raw `docker build` commands with `docker/build-push-action@v6` for both build jobs
- Added `docker/setup-buildx-action@v3` to enable Docker Buildx support
- Implemented GitHub Actions cache integration (`type=gha`) for both full and simple app builds with separate cache scopes
- Configured `load: true` to load built images into Docker daemon for local testing

## Implementation Details
- Each build job now has its own cache scope (`full-app` and `simple-app`) to prevent cache conflicts
- Cache mode set to `max` to maximize cache reuse across builds
- The structured approach using `docker/build-push-action` provides better integration with GitHub Actions and improved build performance through layer caching

https://claude.ai/code/session_01URHRBGmtAaVif55VvwnjNu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker image build workflow with enhanced build tooling and intelligent caching strategies to reduce build times and improve CI/CD pipeline efficiency.
  * Upgraded GitHub Actions dependencies to latest stable versions for improved reliability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->