### PR TITLE
Add CLAUDE.md and Claude Code skills for MS webapp development

### DIFF
--- a/.claude/skills/add-presets.md
+++ b/.claude/skills/add-presets.md
@@ -1,0 +1,98 @@
+# Add Parameter Presets
+
+Add or modify parameter presets for a TOPP workflow in `presets.json`.
+
+## Instructions
+
+1. **Ask the user** for:
+   - Which workflow the presets are for
+   - Preset names and descriptions
+   - Parameter values for each preset (TOPP tool parameters and/or custom widget parameters)
+
+2. **Determine the workflow key** from the display name:
+   - Convert to lowercase, replace spaces with hyphens
+   - Example: "TOPP Workflow" -> "topp-workflow"
+   - Example: "Metabolite Analysis" -> "metabolite-analysis"
+
+3. **Read or create `presets.json`** at the repository root. Add entries following this schema:
+
+```json
+{
+  "workflow-name": {
+    "Preset Name": {
+      "_description": "Tooltip text shown on hover over the preset button",
+      "TOPPToolName": {
+        "algorithm:section:param_name": value
+      },
+      "_general": {
+        "custom-widget-key": value
+      }
+    }
+  }
+}
+```
+
+4. **Verify the result** by checking that:
+   - Workflow name key matches the name passed to `WorkflowManager.__init__()` (lowercased, hyphenated)
+   - TOPP tool names match those used in `input_TOPP()` calls
+   - Parameter paths use colon-separated format matching the TOPP tool's .ini structure
+   - `_general` keys match widget keys from `input_widget()` calls
+   - JSON is valid
+
+## Schema Rules
+
+- **Workflow key**: lowercase, hyphens — must match `WorkflowManager("Display Name", ...)` converted
+- **`_description`**: optional tooltip text for the preset button
+- **TOPP tool keys**: dictionary name must exactly match the TOPP tool name (e.g., `"FeatureFinderMetabo"`)
+- **TOPP parameter paths**: colon-separated, e.g., `"algorithm:common:noise_threshold_int"`
+- **`_general`**: overrides for custom `input_widget()` keys (non-TOPP parameters)
+- **Keys starting with `_`** are metadata and not applied as tool parameters
+
+## How Presets Work at Runtime
+
+1. Preset buttons auto-appear in `parameter_section()` via `StreamlitUI.preset_buttons()`
+2. Only presets matching the current workflow name are displayed
+3. Clicking a preset updates `params.json` in the workspace and refreshes the UI
+4. If no `presets.json` exists or no presets match, no buttons are shown
+
+## Reference Files
+
+- Existing presets: `presets.json`
+- Preset loading: `src/workflow/ParameterManager.py`
+- Preset buttons: `src/workflow/StreamlitUI.py` — `preset_buttons()` method
+- Documentation: `docs/build_app.md` (Parameter Presets section)
+
+## Example
+
+For a workflow initialized as `super().__init__("Feature Analysis", ...)`:
+
+```json
+{
+  "feature-analysis": {
+    "High Sensitivity": {
+      "_description": "Optimized for detecting low-abundance features",
+      "FeatureFinderMetabo": {
+        "algorithm:common:noise_threshold_int": 500.0,
+        "algorithm:common:chrom_peak_snr": 2.0
+      }
+    },
+    "Fast Processing": {
+      "_description": "Quick analysis with relaxed thresholds",
+      "FeatureFinderMetabo": {
+        "algorithm:common:noise_threshold_int": 2000.0
+      },
+      "_general": {
+        "run-python-script": false
+      }
+    }
+  }
+}
+```
+
+## Checklist
+
+- [ ] Workflow key is lowercase with hyphens, matching the WorkflowManager name
+- [ ] Each preset has a descriptive `_description`
+- [ ] TOPP tool names match exactly
+- [ ] Parameter paths use colon-separated format
+- [ ] `presets.json` is valid JSON

--- a/.claude/skills/add-python-tool.md
+++ b/.claude/skills/add-python-tool.md
@@ -1,0 +1,116 @@
+# Add a Python Analysis Tool
+
+Add a custom Python analysis script to `src/python-tools/` with auto-generated UI.
+
+## Instructions
+
+1. **Ask the user** for:
+   - Tool name (lowercase, hyphens for spaces)
+   - What the tool does
+   - Input/output file types
+   - Parameters: name, type, default value, constraints
+
+2. **Create the tool script** at `src/python-tools/<name>.py`:
+
+```python
+import json
+import sys
+
+DEFAULTS = [
+    # Hidden I/O parameters (always include these)
+    {"key": "in", "value": [], "help": "Input files.", "hide": True},
+    {"key": "out", "value": [], "help": "Output files.", "hide": True},
+    # Visible parameters — examples of each type:
+    {
+        "key": "threshold",
+        "value": 1000.0,
+        "name": "Intensity Threshold",
+        "help": "Minimum intensity for filtering.",
+        "min": 0.0,
+        "max": 100000.0,
+        "step_size": 100.0,
+    },
+    {
+        "key": "method",
+        "value": "default",
+        "name": "Processing Method",
+        "options": ["default", "advanced", "custom"],
+        "help": "Which algorithm to use.",
+    },
+    {
+        "key": "num-features",
+        "value": 10,
+        "name": "Number of Features",
+        "widget_type": "slider",
+        "min": 1,
+        "max": 100,
+        "step_size": 1,
+        "help": "How many features to report.",
+    },
+    {
+        "key": "advanced-setting",
+        "value": 5,
+        "name": "Advanced Setting",
+        "help": "Only shown in advanced mode.",
+        "advanced": True,
+    },
+    {
+        "key": "enabled",
+        "value": True,
+        "name": "Enable Processing",
+    },
+]
+
+
+def get_params():
+    if len(sys.argv) > 1:
+        with open(sys.argv[1], "r") as f:
+            return json.load(f)
+    else:
+        return {}
+
+
+if __name__ == "__main__":
+    params = get_params()
+    # Tool logic here — read inputs, process, write outputs
+```
+
+3. **Wire into a workflow** by adding to the workflow's `configure()` and `execution()` methods:
+
+```python
+# In configure():
+self.ui.input_python("tool_name")
+
+# In execution():
+self.executor.run_python("tool_name", {"in": input_files})
+```
+
+## DEFAULTS Metadata Keys
+
+| Key | Required | Type | Description |
+|-----|----------|------|-------------|
+| `key` | Yes | str | Unique identifier for the parameter |
+| `value` | Yes | any | Default value (type determines widget: bool=checkbox, str with options=selectbox, number=number_input) |
+| `name` | No | str | Display name in the UI |
+| `help` | No | str | Tooltip text |
+| `hide` | No | bool | If `True`, parameter is not shown in UI (use for in/out files) |
+| `options` | No | list | Valid choices — renders as selectbox |
+| `min` | No | number | Minimum value for numeric inputs |
+| `max` | No | number | Maximum value for numeric inputs |
+| `step_size` | No | number | Step size for numeric inputs |
+| `widget_type` | No | str | Override widget type: `"slider"`, `"textarea"`, `"number"`, `"text"`, etc. |
+| `advanced` | No | bool | If `True`, only shown when user expands advanced parameters |
+
+## Reference Files
+
+- Example tool: `src/python-tools/example.py`
+- Another example: `src/python-tools/export_consensus_feature_df.py`
+- UI generation: `src/workflow/StreamlitUI.py` — `input_python()` method
+- Execution: `src/workflow/CommandExecutor.py` — `run_python()` method
+
+## Checklist
+
+- [ ] Script created in `src/python-tools/` with DEFAULTS list
+- [ ] `get_params()` function and `__main__` block included
+- [ ] `in` and `out` keys in DEFAULTS with `"hide": True`
+- [ ] Wired into workflow via `self.ui.input_python()` and `self.executor.run_python()`

--- a/.claude/skills/add-python-tool.md
+++ b/.claude/skills/add-python-tool.md
@@ -1,6 +1,8 @@
 # Add a Python Analysis Tool
 
-Add a custom Python analysis script to `src/python-tools/` with auto-generated UI.
+Add a custom Python analysis script for MS data processing to `src/python-tools/` with auto-generated UI.
+
+Python tools handle analysis steps that aren't covered by TOPP tools — e.g., exporting consensus features to DataFrames, computing differential expression statistics, custom metabolite annotation, or post-processing identification results.
 
 ## Instructions
 

--- a/.claude/skills/add-visualization.md
+++ b/.claude/skills/add-visualization.md
@@ -1,6 +1,8 @@
-# Add Visualization
+# Add MS Data Visualization
 
-Add MS data visualizations using pyopenms-viz or OpenMS-Insight components.
+Add mass spectrometry data visualizations using pyopenms-viz or OpenMS-Insight components.
+
+MS data has specialized visualization needs: mass spectra (m/z vs intensity stick plots), chromatograms (RT vs intensity), 2D peak maps (RT vs m/z heatmaps), isotope patterns, fragment ion annotations, and statistical plots like volcano plots for differential expression.
 
 ## Instructions
 

--- a/.claude/skills/add-visualization.md
+++ b/.claude/skills/add-visualization.md
@@ -1,0 +1,132 @@
+# Add Visualization
+
+Add MS data visualizations using pyopenms-viz or OpenMS-Insight components.
+
+## Instructions
+
+1. **Ask the user** for:
+   - What data to visualize (spectra, chromatograms, peak maps, tables, heatmaps)
+   - Data size expectations (small/medium vs. large datasets with millions of points)
+   - Whether interactive cross-component linking is needed
+
+2. **Choose the right library**:
+
+| Use Case | Library | Why |
+|----------|---------|-----|
+| Quick spectrum/chromatogram/peak map plots | **pyopenms-viz** | Simple one-liner API, publication quality |
+| Large datasets (millions of points) | **OpenMS-Insight** | Server-side pagination, intelligent downsampling |
+| Interactive tables with pagination | **OpenMS-Insight** `Table` | Tabulator.js, CSV export, server-side filtering |
+| Cross-linked views (click table row → highlight in plot) | **OpenMS-Insight** | Shared `link_id` across components |
+| Standard Plotly plots (bar, scatter, etc.) | **plotly.express** directly | Already available, use with `show_fig()` |
+
+3. **Implement the visualization** in a page or workflow results section.
+
+## pyopenms-viz Patterns
+
+pyopenms-viz extends pandas DataFrames with MS-specific plot accessors. Always use the `plotly` backend for Streamlit.
+
+```python
+import pyopenms_viz
+from src.common.common import show_fig
+
+# Mass spectrum (stick plot from mz/intensity columns)
+fig = df.plot.ms_spectrum(backend="plotly", title="MS1 Spectrum")
+show_fig(fig, "spectrum-plot")
+
+# 2D peak map (RT vs m/z, colored by intensity)
+fig = df.plot.peak_map(backend="plotly")
+show_fig(fig, "peak-map")
+
+# Chromatogram (RT vs intensity)
+fig = df.plot.chromatogram(backend="plotly")
+show_fig(fig, "chromatogram")
+
+# Mobilogram (ion mobility vs intensity)
+fig = df.plot.mobilogram(backend="plotly")
+show_fig(fig, "mobilogram")
+```
+
+**Key points:**
+- DataFrame must have appropriate columns (e.g., `mz`, `intensity` for spectra)
+- Always use `backend="plotly"` in Streamlit context
+- Use `show_fig()` from `src/common/common.py` for consistent display with download buttons
+- Import `pyopenms_viz` to register the plot accessors (even if not used directly)
+
+## OpenMS-Insight Patterns
+
+OpenMS-Insight provides Vue.js-backed interactive components optimized for large MS datasets.
+
+```python
+from openms_insight import Table, LinePlot, Heatmap, VolcanoPlot, SequenceView
+
+# Interactive table with server-side pagination
+Table(df, key="results-table", page_size=50)
+
+# Stick-style mass spectrum
+LinePlot(df, x="mz", y="intensity", key="spectrum-plot")
+
+# 2D heatmap for large datasets (auto-downsampling)
+Heatmap(df, x="rt", y="mz", z="intensity", key="peak-heatmap")
+
+# Volcano plot for differential expression
+VolcanoPlot(df, x="log2fc", y="neg_log10_pval", key="volcano")
+
+# Peptide sequence with fragment ion annotations
+SequenceView(sequence="PEPTIDER", ions=ion_df, key="sequence")
+```
+
+### Cross-Component Linking
+
+Link components so selections in one update another:
+
+```python
+# Selecting a row in the table highlights the corresponding point in the plot
+Table(df, key="linked-table", link_id="feature_id")
+LinePlot(df, x="mz", y="intensity", key="linked-plot", link_id="feature_id")
+Heatmap(df, x="rt", y="mz", z="intensity", key="linked-heatmap", link_id="feature_id")
+```
+
+All components sharing the same `link_id` column are automatically synchronized.
+
+## Integration in Workflow Results
+
+Add visualization to a workflow's `results()` method:
+
+```python
+@st.fragment
+def results(self) -> None:
+    result_file = Path(self.workflow_dir, "results", "step-name", "output.tsv")
+    if result_file.exists():
+        df = pd.read_csv(result_file, sep="\t")
+
+        # pyopenms-viz for spectrum plots
+        import pyopenms_viz
+        fig = df.plot.ms_spectrum(backend="plotly")
+        show_fig(fig, "results-spectrum")
+
+        # Or OpenMS-Insight for interactive exploration
+        from openms_insight import Table
+        Table(df, key="results-table")
+    else:
+        st.warning("No results found. Please run the workflow first.")
+```
+
+## Reference Files
+
+- Display utilities: `src/common/common.py` — `show_fig()`, `show_table()`
+- Dependencies: `requirements.txt` — `pyopenms-viz`, `openms-insight`
+- Example workflow results: `src/Workflow.py` — `results()` method
+
+## Library Repositories
+
+- **pyopenms-viz**: OpenMS/pyopenms-viz — pandas DataFrame `.plot()` extension with matplotlib/bokeh/plotly backends
+- **OpenMS-Insight**: t0mdavid-m/openms-insight — Vue.js interactive Streamlit components with caching and downsampling
+
+## Checklist
+
+- [ ] Correct library chosen for the use case
+- [ ] Dependencies present in `requirements.txt`
+- [ ] `show_fig()` used for pyopenms-viz plots (consistent download/export behavior)
+- [ ] `backend="plotly"` specified for all pyopenms-viz plots
+- [ ] Unique `key=` values for all OpenMS-Insight components
+- [ ] Cross-component linking set up if multiple views of same data

--- a/.claude/skills/configure-deployment.md
+++ b/.claude/skills/configure-deployment.md
@@ -1,0 +1,94 @@
+# Configure Deployment
+
+Set up Docker, settings, and CI/CD configuration for a new or forked app.
+
+## Instructions
+
+1. **Ask the user** for:
+   - App name (display name, e.g., "UmetaFlow")
+   - GitHub user/organization and repository name
+   - Whether the app needs TOPP tools (determines Dockerfile choice)
+   - Deployment mode: local only, online, or both
+
+2. **Update `settings.json`**:
+
+```json
+{
+    "app-name": "Your App Name",
+    "github-user": "YourGitHubUser",
+    "repository-name": "your-repo-name",
+    "version": "0.1.0",
+    "online_deployment": false,
+    "enable_workspaces": true
+}
+```
+
+Key fields: `app-name`, `github-user`, `repository-name`, `version`, `online_deployment`, `max_threads`.
+
+3. **Choose and update Dockerfile**:
+
+   - **`Dockerfile`** (full): builds OpenMS from source with TOPP tools. Use when the app runs TOPP tools via `executor.run_topp()`. Update:
+     - `GITHUB_USER` and `GITHUB_REPO` environment variables
+     - Python dependencies in `environment.yml`
+     - Entrypoint if main file is not `app.py`
+
+   - **`Dockerfile_simple`** (lightweight): installs pyOpenMS via pip only. Use when the app only uses pyOpenMS Python API. Update:
+     - `GITHUB_USER` and `GITHUB_REPO` environment variables
+     - Python dependencies in `requirements.txt`
+
+4. **Update `docker-compose.yml`**:
+
+```yaml
+services:
+  your-app-name:
+    build: .
+    ports:
+      - "8501:8501"
+    volumes:
+      - workspaces-your-repo-name:/workspaces-your-repo-name
+
+volumes:
+  workspaces-your-repo-name:
+```
+
+Service name and volume name should use the repository name.
+
+5. **Update `clean-up-workspaces.py`**:
+
+```python
+workspaces_directory = Path("/workspaces-your-repo-name")
+```
+
+6. **Update `README.md`** with the new app name, description, and instructions.
+
+## Dockerfile Decision Guide
+
+| App Type | Dockerfile | Why |
+|----------|-----------|-----|
+| Uses TOPP tools (FeatureFinder, etc.) | `Dockerfile` | Needs compiled OpenMS binaries |
+| Pure pyOpenMS / Python only | `Dockerfile_simple` | Lighter, faster build |
+| Vue.js components (like FLASHApp) | `Dockerfile` + build step | Needs npm build for JS components |
+
+## Reference Files
+
+- App settings: `settings.json`
+- Docker: `Dockerfile`, `Dockerfile_simple`, `docker-compose.yml`
+- Build docs: `docs/build_app.md`
+- Deployment docs: `docs/deployment.md`
+- CI/CD: `.github/workflows/` (Docker build, Windows exe, linting, tests)
+- Workspace cleanup: `clean-up-workspaces.py`
+
+## Real-World Examples
+
+- **quantms-web**: Full Dockerfile with TOPP tools, online deployment with Redis queue
+- **umetaflow**: Full Dockerfile, metabolomics TOPP tools, hosted at abi-services.cs.uni-tuebingen.de
+- **FLASHApp**: Full Dockerfile + Vue.js component build step, `develop` as default branch
+
+## Checklist
+
+- [ ] `settings.json` updated with app name, GitHub user/repo, version
+- [ ] Correct Dockerfile chosen and configured (GITHUB_USER, GITHUB_REPO)
+- [ ] `docker-compose.yml` updated with service name and volume
+- [ ] `clean-up-workspaces.py` updated with workspace directory path
+- [ ] `requirements.txt` or `environment.yml` updated with dependencies
+- [ ] `README.md` updated

--- a/.claude/skills/create-page.md
+++ b/.claude/skills/create-page.md
@@ -1,0 +1,62 @@
+# Create a New Streamlit Page
+
+Add a new page to the OpenMS web application.
+
+## Instructions
+
+1. **Ask the user** for:
+   - Page name and icon (emoji)
+   - Which section in the sidebar it belongs to (look at existing sections in `app.py`)
+   - Whether it needs tracked parameters
+   - Whether it's a standalone page or part of a workflow
+
+2. **Create the page file** at `content/<page_name>.py` following this pattern:
+
+```python
+import streamlit as st
+from src.common.common import page_setup, save_params
+
+params = page_setup()
+
+st.title("Page Title")
+
+# Page content here using Streamlit components
+# For tracked parameters, use matching keys:
+# st.number_input("Label", value=params["my-key"], key="my-key")
+
+save_params(params)
+```
+
+3. **Register the page** in `app.py` by adding an entry to the `pages` dictionary:
+
+```python
+st.Page(Path("content", "<page_name>.py"), title="Page Title", icon="🔬"),
+```
+
+Add to an existing section or create a new section key in the dict.
+
+4. **Add default parameters** if the page uses tracked widget state. Add entries to `default-parameters.json` with keys matching the widget `key=` arguments.
+
+5. **Create source logic** if the page has non-trivial logic. Put it in `src/<page_name>.py` and import from the page file.
+
+## Reference Files
+
+- Existing pages: `content/` directory (e.g., `content/quickstart.py`, `content/digest.py`)
+- Page setup function: `src/common/common.py` — `page_setup()`, `save_params()`, `show_fig()`, `show_table()`
+- App entry point: `app.py` (page registration in pages dict)
+- Default parameters: `default-parameters.json`
+
+## Real-World Examples
+
+- **quantms-web** (OpenMS/quantms-web) adds proteomics-specific pages for quantification results, quality control, and statistical analysis
+- **umetaflow** (OpenMS/umetaflow) adds metabolomics pages for feature detection, annotation, and EIC extraction
+- **FLASHApp** (OpenMS/FLASHApp) adds specialized visualization pages for FLASHDeconv results with custom Vue.js components
+
+## Checklist
+
+- [ ] Page file created in `content/`
+- [ ] Page registered in `app.py` pages dict
+- [ ] Default parameters added to `default-parameters.json` (if any)
+- [ ] `page_setup()` called at top of page
+- [ ] `save_params(params)` called at bottom of page
+- [ ] Source logic in `src/` if non-trivial

--- a/.claude/skills/create-workflow.md
+++ b/.claude/skills/create-workflow.md
@@ -1,15 +1,18 @@
 # Create a TOPP Workflow
 
-Create a complete TOPP workflow: a WorkflowManager subclass and its 4 associated content pages.
+Create a complete mass spectrometry data processing workflow: a WorkflowManager subclass and its 4 associated content pages.
+
+This is how MS analysis pipelines (proteomics quantification, metabolomics feature detection, peptide identification, etc.) are built as web applications in the OpenMS ecosystem.
 
 ## Instructions
 
 1. **Ask the user** for:
-   - Workflow name (e.g., "Metabolite Quantification")
-   - TOPP tools to use in the pipeline (e.g., FeatureFinderMetabo, FeatureLinkerUnlabeledKD)
-   - Input file type(s) (e.g., mzML, featureXML)
-   - Any custom Python tools needed
-   - What results to display
+   - Workflow name (e.g., "Metabolite Quantification", "Peptide Identification")
+   - Scientific purpose (e.g., label-free quantification, untargeted metabolomics, spectral library search)
+   - TOPP tools to chain in the pipeline (e.g., FeatureFinderMetabo → FeatureLinkerUnlabeledKD, or MSGFPlusAdapter → FidoAdapter)
+   - Input file type(s): mzML (raw spectra), featureXML (features), idXML (identifications), fasta (protein databases), etc.
+   - Any custom Python analysis tools needed
+   - What results to display (feature tables, spectra, chromatograms, statistical plots)
 
 2. **Create the workflow class** at `src/<WorkflowName>.py`:
 

--- a/.claude/skills/create-workflow.md
+++ b/.claude/skills/create-workflow.md
@@ -1,0 +1,146 @@
+# Create a TOPP Workflow
+
+Create a complete TOPP workflow: a WorkflowManager subclass and its 4 associated content pages.
+
+## Instructions
+
+1. **Ask the user** for:
+   - Workflow name (e.g., "Metabolite Quantification")
+   - TOPP tools to use in the pipeline (e.g., FeatureFinderMetabo, FeatureLinkerUnlabeledKD)
+   - Input file type(s) (e.g., mzML, featureXML)
+   - Any custom Python tools needed
+   - What results to display
+
+2. **Create the workflow class** at `src/<WorkflowName>.py`:
+
+```python
+import streamlit as st
+from src.workflow.WorkflowManager import WorkflowManager
+from pathlib import Path
+
+class MyWorkflow(WorkflowManager):
+    def __init__(self) -> None:
+        super().__init__("My Workflow", st.session_state["workspace"])
+
+    def upload(self) -> None:
+        t = st.tabs(["MS data"])
+        with t[0]:
+            self.ui.upload_widget(
+                key="mzML-files",
+                name="MS data",
+                file_types="mzML",
+                fallback=[str(f) for f in Path("example-data", "mzML").glob("*.mzML")],
+            )
+
+    @st.fragment
+    def configure(self) -> None:
+        self.ui.select_input_file("mzML-files", multiple=True)
+        t = st.tabs(["**Step 1**", "**Step 2**"])
+        with t[0]:
+            self.ui.input_TOPP("ToolName1")
+        with t[1]:
+            self.ui.input_TOPP("ToolName2")
+
+    def execution(self) -> None:
+        if not self.params["mzML-files"]:
+            self.logger.log("ERROR: No input files selected.")
+            return
+
+        in_files = self.file_manager.get_files(self.params["mzML-files"])
+        self.logger.log(f"Processing {len(in_files)} files...")
+
+        # Step 1
+        out_step1 = self.file_manager.get_files(in_files, "featureXML", "step1")
+        self.executor.run_topp("ToolName1", input_output={"in": in_files, "out": out_step1})
+
+        # Step 2
+        in_step2 = self.file_manager.get_files(out_step1, collect=True)
+        out_step2 = self.file_manager.get_files("result.consensusXML", set_results_dir="step2")
+        self.executor.run_topp("ToolName2", input_output={"in": in_step2, "out": out_step2})
+
+    @st.fragment
+    def results(self) -> None:
+        result_file = Path(self.workflow_dir, "results", "step2", "result.tsv")
+        if result_file.exists():
+            import pandas as pd
+            df = pd.read_csv(result_file, sep="\t")
+            st.dataframe(df)
+        else:
+            st.warning("No results found. Please run the workflow first.")
+```
+
+3. **Create 4 content pages** in `content/`. Each follows this minimal pattern:
+
+```python
+# content/<workflow_name>_file_upload.py
+from src.common.common import page_setup
+from src.<WorkflowName> import MyWorkflow
+params = page_setup()
+wf = MyWorkflow()
+wf.show_file_upload_section()
+```
+
+The 4 pages call these methods respectively:
+- `wf.show_file_upload_section()` — upload page
+- `wf.show_parameter_section()` — configure page
+- `wf.show_execution_section()` — run page
+- `wf.show_results_section()` — results page
+
+4. **Register all 4 pages** as a group in `app.py`:
+
+```python
+"My Workflow": [
+    st.Page(Path("content", "my_workflow_file_upload.py"), title="File Upload", icon="📁"),
+    st.Page(Path("content", "my_workflow_parameter.py"), title="Configure", icon="⚙️"),
+    st.Page(Path("content", "my_workflow_execution.py"), title="Run", icon="🚀"),
+    st.Page(Path("content", "my_workflow_results.py"), title="Results", icon="📊"),
+],
+```
+
+5. **Add default parameters** to `default-parameters.json` if the workflow introduces new tracked widget keys.
+
+## Key APIs
+
+### File management
+- `self.file_manager.get_files(input_files)` — resolve file paths in workspace
+- `self.file_manager.get_files(in_files, "ext", "step-name")` — create output paths
+- `self.file_manager.get_files(files, collect=True)` — collect multiple files into single list argument
+- `self.file_manager.get_files("name.ext", set_results_dir="dir")` — single result file
+
+### Execution
+- `self.executor.run_topp("ToolName", input_output={"in": [...], "out": [...]})` — run a TOPP tool
+- `self.executor.run_python("script_name", {"in": [...]})` — run a Python tool from `src/python-tools/`
+
+### UI widgets
+- `self.ui.upload_widget(key, name, file_types, fallback)` — file upload with example data fallback
+- `self.ui.select_input_file(key, multiple)` — select from uploaded files
+- `self.ui.input_TOPP("ToolName", custom_defaults={})` — auto-generated TOPP parameter UI
+- `self.ui.input_python("script_name")` — auto-generated Python tool parameter UI
+- `self.ui.input_widget(key, default, label)` — single custom widget
+
+### Logging
+- `self.logger.log("message")` — log progress during execution
+
+## Reference Files
+
+- Example workflow: `src/Workflow.py`
+- Workflow base class: `src/workflow/WorkflowManager.py`
+- UI widget library: `src/workflow/StreamlitUI.py`
+- Example pages: `content/topp_workflow_file_upload.py`, `content/topp_workflow_parameter.py`, `content/topp_workflow_execution.py`, `content/topp_workflow_results.py`
+- Command executor: `src/workflow/CommandExecutor.py`
+- File manager: `src/workflow/FileManager.py`
+
+## Real-World Examples
+
+- **umetaflow** (OpenMS/umetaflow): multi-step metabolomics pipeline — feature detection, linking, annotation, statistics
+- **quantms-web** (OpenMS/quantms-web): proteomics quantification pipeline with DDA-LFQ, DDA-ISO, DIA-LFQ modes
+
+## Checklist
+
+- [ ] Workflow class in `src/` subclassing `WorkflowManager`
+- [ ] `__init__` calls `super().__init__("Name", st.session_state["workspace"])`
+- [ ] `upload()`, `configure()`, `execution()`, `results()` implemented
+- [ ] `@st.fragment` on `configure()` and `results()`
+- [ ] 4 content pages created in `content/`
+- [ ] All 4 pages registered as a group in `app.py`
+- [ ] Default parameters added to `default-parameters.json` if needed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,153 @@
+# OpenMS Streamlit WebApp Template
+
+## Project Overview
+
+This is the base template for building mass spectrometry (MS) web applications using Streamlit and OpenMS/pyOpenMS. All OpenMS web apps are derived from this template, including:
+
+- **OpenMS/quantms-web** — quantitative proteomics workflows
+- **OpenMS/umetaflow** — untargeted metabolomics analysis (UmetaFlow pipeline)
+- **OpenMS/FLASHApp** — top-down proteomics visualization (FLASHDeconv results)
+
+These derived apps customize the template by adding domain-specific workflows, pages, and tools while inheriting the core framework.
+
+## Architecture
+
+```
+app.py                          # Entry point — registers pages via st.Page() in a dict
+settings.json                   # App config: name, version, deployment mode, threading
+default-parameters.json         # Default workspace parameters (tracked via widget keys)
+presets.json                    # Parameter presets for TOPP workflows
+content/                        # Streamlit pages (one .py per page)
+src/
+  common/common.py              # Utilities: page_setup(), save_params(), show_fig(), show_table()
+  Workflow.py                   # Example WorkflowManager subclass (TOPP workflow)
+  workflow/
+    WorkflowManager.py          # Base class: upload/configure/execution/results pattern
+    StreamlitUI.py              # Widget library: upload_widget, input_TOPP, input_python, etc.
+    ParameterManager.py         # JSON parameter persistence + TOPP .ini generation
+    CommandExecutor.py           # Runs TOPP tools and Python scripts as subprocesses
+    FileManager.py              # Workspace file organization
+    Logger.py                   # Structured workflow logging
+    QueueManager.py             # Redis queue for online deployments
+  python-tools/                 # Custom Python analysis scripts (with DEFAULTS dicts)
+Dockerfile                      # Full build: OpenMS + TOPP tools + pyOpenMS
+Dockerfile_simple               # Lightweight: pyOpenMS only
+docker-compose.yml              # Deployment config
+```
+
+## Key Patterns
+
+### Pages
+
+Every page starts with `page_setup()` which handles workspace initialization, sidebar rendering, and parameter loading:
+
+```python
+from src.common.common import page_setup
+params = page_setup()
+```
+
+Pages are registered in `app.py` under named sections:
+
+```python
+pages = {
+    "Section Name": [
+        st.Page(Path("content", "my_page.py"), title="My Page", icon="🔬"),
+    ],
+}
+```
+
+### Parameters
+
+Parameters are tracked via widget keys that match entries in `default-parameters.json`. The `save_params(params)` call at the end of a page persists any widget state changes:
+
+```python
+params = page_setup()
+st.number_input("X", value=params["my-param"], key="my-param")
+save_params(params)
+```
+
+### TOPP Workflows (WorkflowManager)
+
+Complex workflows subclass `WorkflowManager` and implement 4 methods:
+- `upload()` — file upload widgets via `self.ui.upload_widget()`
+- `configure()` — TOPP params via `self.ui.input_TOPP()`, Python tool params via `self.ui.input_python()`
+- `execution()` — run tools via `self.executor.run_topp()` and `self.executor.run_python()`
+- `results()` — display outputs
+
+Each workflow gets 4 content pages (upload, configure, run, results) that call `wf.show_*_section()`.
+
+Decorate `configure()` and `results()` with `@st.fragment` for partial reruns.
+
+### Python Tools
+
+Custom scripts in `src/python-tools/` define a `DEFAULTS` list for auto-generated UI:
+
+```python
+DEFAULTS = [
+    {"key": "in", "value": [], "hide": True},
+    {"key": "my-param", "value": 5, "name": "My Parameter", "help": "Description",
+     "min": 1, "max": 100, "step_size": 1, "widget_type": "slider"},
+]
+```
+
+### Presets
+
+Parameter presets in `presets.json` map workflow names (lowercase, hyphens) to named parameter sets:
+
+```json
+{
+  "workflow-name": {
+    "Preset Name": {
+      "_description": "Tooltip text",
+      "TOPPToolName": {"algorithm:section:param": value},
+      "_general": {"custom-key": value}
+    }
+  }
+}
+```
+
+## Visualization Libraries
+
+Two libraries are commonly used in template-based apps:
+
+### pyopenms-viz
+Pandas DataFrame extension for MS visualization. Use the plotly backend in Streamlit:
+```python
+import pyopenms_viz
+df.plot.ms_spectrum(backend="plotly")  # spectrum plot
+df.plot.peak_map(backend="plotly")     # 2D peak map
+df.plot.chromatogram(backend="plotly") # chromatogram
+```
+
+### OpenMS-Insight (t0mdavid-m/openms-insight)
+Vue.js-backed interactive Streamlit components for large MS datasets:
+- `Table` — server-side pagination with Tabulator.js
+- `LinePlot` — stick-style mass spectra via Plotly
+- `Heatmap` — 2D scatter handling millions of points
+- `VolcanoPlot` — differential expression visualization
+- `SequenceView` — peptide sequence with fragment ion matching
+
+Components support cross-linking via shared identifiers.
+
+## Commands
+
+```bash
+# Run locally
+pip install -r requirements.txt
+streamlit run app.py
+
+# Run tests
+python -m pytest tests/
+
+# Docker
+docker-compose up --build
+```
+
+## Conventions
+
+- Page files go in `content/`, source logic in `src/`
+- Widget keys must match parameter keys in `default-parameters.json`
+- Workflow names use lowercase with hyphens: "My Workflow" -> "my-workflow"
+- Use `show_fig()` and `show_table()` from `src/common/common.py` for consistent display
+- Use `@st.fragment` on methods that should partially rerun (configure, results)
+- TOPP tool parameters use colon-separated paths: `"algorithm:section:param_name"`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,25 @@
 # OpenMS Streamlit WebApp Template
 
-## Project Overview
+## What This Is
 
-This is the base template for building mass spectrometry (MS) web applications using Streamlit and OpenMS/pyOpenMS. All OpenMS web apps are derived from this template, including:
+**This is the standard framework for building web applications for mass spectrometry (MS) data analysis**, used across the OpenMS ecosystem for proteomics and metabolomics research. When a researcher or developer needs a web-based tool for MS data processing, visualization, or analysis — whether for label-free quantification, untargeted metabolomics, top-down proteomics, or any other MS workflow — this template is how it gets built.
 
-- **OpenMS/quantms-web** — quantitative proteomics workflows
-- **OpenMS/umetaflow** — untargeted metabolomics analysis (UmetaFlow pipeline)
-- **OpenMS/FLASHApp** — top-down proteomics visualization (FLASHDeconv results)
+The template wraps **OpenMS/pyOpenMS** (the leading open-source C++/Python library for computational mass spectrometry) and its **TOPP tools** (a suite of ~200 command-line tools for MS data processing pipelines) into interactive Streamlit web applications.
 
-These derived apps customize the template by adding domain-specific workflows, pages, and tools while inheriting the core framework.
+### Production Apps Built From This Template
+
+- **OpenMS/quantms-web** — quantitative proteomics (DDA-LFQ, DDA-ISO, DIA-LFQ quantification)
+- **OpenMS/umetaflow** — untargeted metabolomics (feature detection, alignment, annotation, GNPS molecular networking)
+- **OpenMS/FLASHApp** — top-down proteomics (FLASHDeconv deconvolution result visualization)
+
+### Mass Spectrometry Domain Context
+
+- **Input data** is typically mzML (raw MS spectra), featureXML (detected features), consensusXML (linked features across samples), idXML (peptide/protein identifications), traML (targeted transitions)
+- **Typical workflows chain TOPP tools**: e.g., `FeatureFinderMetabo` (detect LC-MS features) → `FeatureLinkerUnlabeledKD` (align features across runs) → custom Python post-processing
+- **Proteomics** focuses on peptide/protein identification and quantification (tools like `MSGFPlusAdapter`, `FidoAdapter`, `ProteinQuantifier`)
+- **Metabolomics** focuses on feature detection, annotation, and statistical analysis (tools like `FeatureFinderMetabo`, `MetaboliteAdductDecharger`, `SiriusAdapter`)
+- **pyOpenMS** provides Python bindings for programmatic MS data access — reading mzML files, manipulating spectra/chromatograms, computing molecular properties, etc.
+- **MS-specific visualizations**: mass spectra (m/z vs intensity), chromatograms (RT vs intensity), peak maps (RT vs m/z 2D heatmaps), isotope patterns, fragment ion annotations, volcano plots for differential expression
 
 ## Architecture
 
@@ -42,7 +53,7 @@ docker-compose.yml              # Deployment config
 Every page starts with `page_setup()` which handles workspace initialization, sidebar rendering, and parameter loading:
 
 ```python
-from src.common.common import page_setup
+from src.common.common import page_setup, save_params
 params = page_setup()
 ```
 
@@ -108,26 +119,33 @@ Parameter presets in `presets.json` map workflow names (lowercase, hyphens) to n
 
 ## Visualization Libraries
 
-Two libraries are commonly used in template-based apps:
+Two libraries are commonly used in template-based apps for MS data visualization:
 
 ### pyopenms-viz
+
 Pandas DataFrame extension for MS visualization. Use the plotly backend in Streamlit:
+
 ```python
 import pyopenms_viz
-df.plot.ms_spectrum(backend="plotly")  # spectrum plot
-df.plot.peak_map(backend="plotly")     # 2D peak map
-df.plot.chromatogram(backend="plotly") # chromatogram
+df.plot.ms_spectrum(backend="plotly")  # mass spectrum (m/z vs intensity)
+df.plot.peak_map(backend="plotly")     # 2D peak map (RT vs m/z heatmap)
+df.plot.chromatogram(backend="plotly") # chromatogram (RT vs intensity)
+df.plot.mobilogram(backend="plotly")   # ion mobility trace
 ```
 
+Best for: publication-quality static/interactive plots, small-medium datasets, standard MS plot types.
+
 ### OpenMS-Insight (t0mdavid-m/openms-insight)
+
 Vue.js-backed interactive Streamlit components for large MS datasets:
+
 - `Table` — server-side pagination with Tabulator.js
 - `LinePlot` — stick-style mass spectra via Plotly
 - `Heatmap` — 2D scatter handling millions of points
 - `VolcanoPlot` — differential expression visualization
 - `SequenceView` — peptide sequence with fragment ion matching
 
-Components support cross-linking via shared identifiers.
+Components support cross-linking via shared identifiers. Best for: large datasets (millions of points), cross-component interactivity, server-side pagination.
 
 ## Commands
 


### PR DESCRIPTION
## Summary

Adds Claude Code project documentation and skills to help developers build and modify mass spectrometry web applications using this template.

### CLAUDE.md — MS domain framing

The `CLAUDE.md` establishes this as **the standard framework for building MS web applications** for proteomics and metabolomics research. It documents:

- **MS domain context**: data types (mzML, featureXML, consensusXML, idXML), TOPP tool pipelines, proteomics vs metabolomics workflows
- **Production apps** built from this template: quantms-web, umetaflow, FLASHApp
- **Architecture**: pages, WorkflowManager pattern, parameter system, presets, python-tools
- **Visualization libraries**: pyopenms-viz (DataFrame `.plot()` extension) and OpenMS-Insight (Vue.js interactive components)

### 6 Claude Code skills (`.claude/skills/`)

| Skill | Purpose |
|-------|---------|
| `/create-page` | Scaffold a new Streamlit page with proper registration |
| `/create-workflow` | Scaffold a full TOPP workflow (WorkflowManager subclass + 4 pages) — asks for scientific purpose, TOPP tools, MS file types |
| `/add-python-tool` | Add a custom Python analysis script with DEFAULTS-based auto-UI |
| `/add-presets` | Add/modify parameter presets in presets.json |
| `/configure-deployment` | Set up Docker, settings.json, and CI/CD for a new app |
| `/add-visualization` | Add pyopenms-viz or OpenMS-Insight MS data visualizations |

Skills reference derived apps (quantms-web, umetaflow, FLASHApp) as real-world examples so Claude can learn from and modify them.

### Recommendations for other repos (not in this PR)

- **pyopenms-viz**: Add CLAUDE.md documenting DataFrame `.plot()` API, plot types, backends. Consider `/add-plot-type` skill.
- **OpenMS-Insight**: Add CLAUDE.md documenting Vue.js component architecture, cross-linking, caching. Consider `/add-component` skill.
- **Derived apps**: Each needs a domain-specific CLAUDE.md and can inherit these template skills. umetaflow and FLASHApp are missing CLAUDE.md files.

## Test plan

- [ ] Verify all 7 new files are present and well-formed markdown
- [ ] Test each skill by invoking it in Claude Code on the template repo
- [ ] Confirm existing tests still pass: `python -m pytest tests/`
- [ ] Confirm `streamlit run app.py` still works

https://claude.ai/code/session_01WYotmLfqRtB8WJXj1Eosiz