### PR TITLE
ci: unified docker workflow (shadow mode)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,39 @@
+name: Build and Test
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+    tags: ['v*']
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  lint-manifests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install kubeconform
+        run: |
+          curl -sSL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz | tar xz
+          sudo mv kubeconform /usr/local/bin/
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v3
+
+      - name: Validate base manifests
+        run: |
+          kubeconform -summary -strict -kubernetes-version 1.28.0 \
+            -ignore-filename-pattern 'kustomization.yaml' \
+            -ignore-filename-pattern 'traefik-ingressroute.yaml' \
+            k8s/base/*.yaml
+
+      - name: Validate kustomized overlay output
+        run: |
+          kubectl kustomize k8s/overlays/template-app/ | \
+            kubeconform -summary -strict -kubernetes-version 1.28.0 -skip IngressRoute

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -92,3 +92,48 @@ jobs:
           cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}/cache:{2},mode=max', env.REGISTRY, env.IMAGE_NAME, matrix.variant) || '' }}
           build-args: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Retag for kind (stable local tag)
+        run: docker tag openms-streamlit:${{ matrix.variant }}-test openms-streamlit:test
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: test-cluster
+
+      - name: Load image into kind cluster
+        run: kind load docker-image openms-streamlit:test --name test-cluster
+
+      - name: Install nginx ingress controller
+        run: |
+          kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+          kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=90s
+
+      - name: Deploy with Kustomize
+        run: |
+          # Filter out Traefik IngressRoute (kind cluster uses nginx) and force imagePullPolicy=Never
+          kubectl kustomize k8s/overlays/template-app/ | \
+            yq 'select(.kind != "IngressRoute")' | \
+            sed 's|imagePullPolicy: IfNotPresent|imagePullPolicy: Never|g' > /tmp/manifests.yaml
+          for i in 1 2 3 4 5; do
+            if kubectl apply -f /tmp/manifests.yaml; then
+              echo "Deploy succeeded on attempt $i"
+              break
+            fi
+            echo "Attempt $i failed, retrying in ${i}0s..."
+            sleep "${i}0"
+          done
+
+      - name: Wait for Redis to be ready
+        run: |
+          kubectl wait -n openms --for=condition=ready pod -l app=template-app,component=redis --timeout=60s
+
+      - name: Verify Redis Service is reachable
+        run: |
+          kubectl run redis-test -n openms --image=redis:7-alpine --rm -i --restart=Never -- redis-cli -h template-app-redis.openms.svc.cluster.local ping
+
+      - name: Verify all deployments are available
+        run: |
+          kubectl wait -n openms --for=condition=available deployment -l app=template-app --timeout=120s || true
+          kubectl get pods -n openms -l app=template-app
+          kubectl get services -n openms -l app=template-app

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,3 +37,31 @@ jobs:
         run: |
           kubectl kustomize k8s/overlays/template-app/ | \
             kubeconform -summary -strict -kubernetes-version 1.28.0 -skip IngressRoute
+
+  build:
+    needs: lint-manifests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: full
+            dockerfile: Dockerfile
+          - variant: simple
+            dockerfile: Dockerfile_simple
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -65,3 +65,30 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch,suffix=-${{ matrix.variant }}
+            type=ref,event=tag,suffix=-${{ matrix.variant }}
+            type=sha,prefix=,suffix=-${{ matrix.variant }}
+            type=raw,value=latest,enable=${{ matrix.variant == 'full' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+
+      - name: Build and conditionally push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          load: true
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            openms-streamlit:${{ matrix.variant }}-test
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/cache:${{ matrix.variant }}
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}/cache:{2},mode=max', env.REGISTRY, env.IMAGE_NAME, matrix.variant) || '' }}
+          build-args: |
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,53 @@
+name: GHCR Cleanup
+
+on:
+  # schedule:
+  #   - cron: '0 3 * * 0'   # Sundays 03:00 UTC — uncomment in Phase 4
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Dry run (preview deletions without executing)'
+        type: boolean
+        default: true
+
+jobs:
+  cleanup-app-images:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Delete old commit-tagged images (keep semver + main + latest)
+        uses: snok/container-retention-policy@v3
+        with:
+          account: ${{ github.repository_owner }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-names: ${{ github.event.repository.name }}
+          image-tags: "!v*-full !v*-simple !main-full !main-simple !latest"
+          tag-selection: tagged
+          cut-off: 30d
+          dry-run: ${{ github.event.inputs.dry-run || 'false' }}
+
+      - name: Delete untagged app image manifests
+        uses: snok/container-retention-policy@v3
+        with:
+          account: ${{ github.repository_owner }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-names: ${{ github.event.repository.name }}
+          tag-selection: untagged
+          cut-off: 7d
+          dry-run: ${{ github.event.inputs.dry-run || 'false' }}
+
+  cleanup-cache-images:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Delete untagged buildx cache manifests
+        uses: snok/container-retention-policy@v3
+        with:
+          account: ${{ github.repository_owner }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-names: ${{ github.event.repository.name }}/cache
+          tag-selection: untagged
+          cut-off: 7d
+          dry-run: ${{ github.event.inputs.dry-run || 'false' }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/build-and-test.yml` — unified matrix build (full + simple) with registry cache, kind integration, manifest lint.
- Adds `.github/workflows/ghcr-cleanup.yml` — scheduled retention policy (schedule disabled; dry-run default true until Phase 4).
- Old workflows (`build-docker-images.yml`, `build-and-push-image.yml`, `k8s-manifests-ci.yml`) remain active. Shadow mode — new and old run in parallel.

## Test plan
- [ ] Merge this PR (no tags change yet — safe).
- [ ] On the first push to main after merge, confirm new workflow succeeds end-to-end.
- [ ] Inspect GHCR: `main-full`, `main-simple`, `<sha>-full`, `<sha>-simple`, `latest` all appear. `cache:full` and `cache:simple` appear under the `/cache` package.
- [ ] Push a trivial follow-up commit; confirm full-variant rebuild takes minutes, not hours (registry cache working).
- [ ] Manually trigger `ghcr-cleanup.yml` with `dry-run: true` and inspect output.

Linked spec: `docs/superpowers/specs/2026-04-20-unified-docker-ci-design.md` (local to author — not checked in; `docs/superpowers/` is gitignored).