### PR TITLE
ci: lowercase image name for OCI cache refs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -55,6 +55,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Compute lowercase image name (OCI refs must be lowercase)
+        run: echo "IMAGE_NAME_LC=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -88,8 +91,8 @@ jobs:
             ${{ steps.meta.outputs.tags }}
             openms-streamlit:${{ matrix.variant }}-test
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/cache:${{ matrix.variant }}
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}/cache:{2},mode=max', env.REGISTRY, env.IMAGE_NAME, matrix.variant) || '' }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}/cache:${{ matrix.variant }}
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}/cache:{2},mode=max', env.REGISTRY, env.IMAGE_NAME_LC, matrix.variant) || '' }}
           build-args: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
Fixes the post-merge `Build and Test` failure on `main` from PR #363.

`github.repository` returns the repository owner in its original casing (`OpenMS/streamlit-template`). Docker OCI references require lowercase, so `cache-from`/`cache-to` in `build-and-test.yml` fail with:

```
ERROR: failed to configure registry cache exporter: invalid reference format:
repository name (OpenMS/streamlit-template/cache) must be lowercase
```

`docker/metadata-action` handles lowercasing internally for its tag output (which is why image tag generation succeeded), but the cache refs bypass it. The fix computes `IMAGE_NAME_LC` once via `${IMAGE_NAME,,}` → `$GITHUB_ENV` and uses it in both cache refs.

## Test plan
- [ ] CI run on this PR passes for both `full` and `simple` matrix legs.
- [ ] Post-merge, the first push to main rebuilds successfully and populates `ghcr.io/openms/streamlit-template/cache:full` and `:simple`.

Failed run being fixed: https://github.com/OpenMS/streamlit-template/actions/runs/24688006892

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker image caching in the CI/CD pipeline to improve build performance and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->