### PR TITLE
ci: don't pass unprefixed local tag to buildx push

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -87,9 +87,7 @@ jobs:
           file: ${{ matrix.dockerfile }}
           load: true
           push: ${{ github.event_name != 'pull_request' }}
-          tags: |
-            ${{ steps.meta.outputs.tags }}
-            openms-streamlit:${{ matrix.variant }}-test
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}/cache:${{ matrix.variant }}
           cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}/cache:{2},mode=max', env.REGISTRY, env.IMAGE_NAME_LC, matrix.variant) || '' }}
@@ -97,7 +95,11 @@ jobs:
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
 
       - name: Retag for kind (stable local tag)
-        run: docker tag openms-streamlit:${{ matrix.variant }}-test openms-streamlit:test
+        run: |
+          # load:true above loaded all meta-action tags into local docker.
+          # Retag the first one to the stable name the kustomize overlay expects.
+          FIRST_TAG=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | head -n 1)
+          docker tag "$FIRST_TAG" openms-streamlit:test
 
       - name: Create kind cluster
         uses: helm/kind-action@v1


### PR DESCRIPTION
## Summary
Fixes the post-merge `Build and Test` failure on `main` from PR #364.

With `push: true`, `docker/build-push-action` pushes every entry in its `tags:` input. My workflow passed both the registry tags from `docker/metadata-action` **and** a bare `openms-streamlit:${{ matrix.variant }}-test` tag. Unprefixed names resolve to Docker Hub (`library/openms-streamlit`), and our `GITHUB_TOKEN` has no write scope there, so buildx fails with:

```
ERROR: failed to fetch oauth token: ... 401 Unauthorized: access token has insufficient scopes
```

PR #364 didn't catch this because PRs run with `push: false`, so buildx built the tag locally without pushing.

## Fix
Remove the local tag from the build-push `tags:` input. Create the stable `openms-streamlit:test` alias that the kustomize overlay expects in a separate `docker tag` step after build — this works because `load: true` has already loaded the metadata-action-tagged image into the runner's docker daemon.

## Test plan
- [ ] CI run on this PR stays green for both matrix legs (same as #364 did before).
- [ ] Post-merge, the run on main passes the `Build and conditionally push` step on both legs (simple's 4-min completion would prove it).
- [ ] Subsequent pushes to main benefit from the populated `cache:*` images.

Failed run being fixed: https://github.com/OpenMS/streamlit-template/actions/runs/24688508237