### PR TITLE
ci: pin container-retention-policy to v3.0.1

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -17,7 +17,7 @@ jobs:
       packages: write
     steps:
       - name: Delete old commit-tagged images (keep semver + main + latest)
-        uses: snok/container-retention-policy@v3
+        uses: snok/container-retention-policy@v3.0.1
         with:
           account: ${{ github.repository_owner }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -28,7 +28,7 @@ jobs:
           dry-run: ${{ github.event.inputs.dry-run || 'false' }}
 
       - name: Delete untagged app image manifests
-        uses: snok/container-retention-policy@v3
+        uses: snok/container-retention-policy@v3.0.1
         with:
           account: ${{ github.repository_owner }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -43,7 +43,7 @@ jobs:
       packages: write
     steps:
       - name: Delete untagged buildx cache manifests
-        uses: snok/container-retention-policy@v3
+        uses: snok/container-retention-policy@v3.0.1
         with:
           account: ${{ github.repository_owner }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
The `ghcr-cleanup.yml` workflow uses `snok/container-retention-policy@v3`, but that floating tag does not exist. The action publishes `v2` (latest floating major) and specific `v3.0.0` / `v3.0.1` tags only. Manual dispatch fails immediately with:

```
Unable to resolve action `snok/container-retention-policy@v3`, unable to find version `v3`
```

Pinning to `v3.0.1` (latest v3 release, published 2025-09-23) resolves it. All three action invocations in the file get the same pin.

## Test plan
- [ ] After merge, manually dispatch `GHCR Cleanup` from the Actions UI with `dry-run: true`.
- [ ] Both jobs (`cleanup-app-images`, `cleanup-cache-images`) must resolve the action and run to completion.
- [ ] The "would delete" output in dry-run mode must not include any `v*-full`, `v*-simple`, `main-full`, `main-simple`, `latest`, or `cache:*` tags.

Failed dispatch being fixed: https://github.com/OpenMS/streamlit-template/actions/runs/24691165923

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container cleanup automation to use a pinned version for improved consistency and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->