### PR TITLE
fix(docker): scope GITHUB_TOKEN to one RUN so registry cache can hit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,6 @@ FROM ubuntu:22.04 AS setup-build-system
 ARG OPENMS_REPO=https://github.com/OpenMS/OpenMS.git
 ARG OPENMS_BRANCH=release/3.5.0
 ARG PORT=8501
-# GitHub token to download latest OpenMS executable for Windows from Github action artifact.
-ARG GITHUB_TOKEN
-ENV GH_TOKEN=${GITHUB_TOKEN}
 # Streamlit app Gihub user name (to download artifact from).
 ARG GITHUB_USER=OpenMS
 # Streamlit app Gihub repository name (to download artifact from).
@@ -227,12 +224,14 @@ RUN mamba run -n streamlit-env python hooks/hook-analytics.py
 # Set Online Deployment
 RUN jq '.online_deployment = true' settings.json > tmp.json && mv tmp.json settings.json
 
-# Download latest OpenMS App executable as a ZIP file
-RUN if [ -n "$GH_TOKEN" ]; then \
-        echo "GH_TOKEN is set, proceeding to download the release asset..."; \
+# Download latest OpenMS App executable as a ZIP file.
+# ARG declared here (not at the top) — otherwise the per-run token busts the cache.
+ARG GITHUB_TOKEN
+RUN if [ -n "$GITHUB_TOKEN" ]; then \
+        echo "GITHUB_TOKEN is set, proceeding to download the release asset..."; \
         gh release download -R ${GITHUB_USER}/${GITHUB_REPO} -p "OpenMS-App.zip" -D /app; \
     else \
-        echo "GH_TOKEN is not set, skipping the release asset download."; \
+        echo "GITHUB_TOKEN is not set, skipping the release asset download."; \
     fi
 
 

--- a/Dockerfile_simple
+++ b/Dockerfile_simple
@@ -11,9 +11,6 @@ FROM ubuntu:22.04 AS stage1
 ARG OPENMS_REPO=https://github.com/OpenMS/OpenMS.git
 ARG OPENMS_BRANCH=develop
 ARG PORT=8501
-# GitHub token to download latest OpenMS executable for Windows from Github action artifact.
-ARG GITHUB_TOKEN
-ENV GH_TOKEN=${GITHUB_TOKEN}
 # Streamlit app Gihub user name (to download artifact from).
 ARG GITHUB_USER=OpenMS
 # Streamlit app Gihub repository name (to download artifact from).
@@ -139,12 +136,14 @@ RUN mamba run -n streamlit-env python hooks/hook-analytics.py
 # Set Online Deployment
 RUN jq '.online_deployment = true' settings.json > tmp.json && mv tmp.json settings.json
 
-# Download latest OpenMS App executable as a ZIP file
-RUN if [ -n "$GH_TOKEN" ]; then \
-        echo "GH_TOKEN is set, proceeding to download the release asset..."; \
+# Download latest OpenMS App executable as a ZIP file.
+# ARG declared here (not at the top) — otherwise the per-run token busts the cache.
+ARG GITHUB_TOKEN
+RUN if [ -n "$GITHUB_TOKEN" ]; then \
+        echo "GITHUB_TOKEN is set, proceeding to download the release asset..."; \
         gh release download -R ${GITHUB_USER}/${GITHUB_REPO} -p "OpenMS-App.zip" -D /app; \
     else \
-        echo "GH_TOKEN is not set, skipping the release asset download."; \
+        echo "GITHUB_TOKEN is not set, skipping the release asset download."; \
     fi
 
 # make sure that mamba environment is used


### PR DESCRIPTION
## Summary
Main builds weren't hitting the buildx cache despite the cache manifest being pulled fine. The `ENV GH_TOKEN=${GITHUB_TOKEN}` at the top of both Dockerfiles baked the per-run token into an early layer, which cache-busted everything downstream. Moved the `ARG GITHUB_TOKEN` next to the one `gh release download` RUN that uses it.

Evidence: runs [24689802413](https://github.com/OpenMS/streamlit-template/actions/runs/24689802413) and [24690644593](https://github.com/OpenMS/streamlit-template/actions/runs/24690644593) both took ~1h8m for the full variant — second should have been a cache hit.

## Test plan
- [ ] Next push to main: full variant drops from ~1h8m to minutes. Simple drops from ~9m to seconds.