### PR TITLE
docs: fix Gihub typo in Dockerfile comments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,9 @@ FROM ubuntu:22.04 AS setup-build-system
 ARG OPENMS_REPO=https://github.com/OpenMS/OpenMS.git
 ARG OPENMS_BRANCH=release/3.5.0
 ARG PORT=8501
-# Streamlit app Gihub user name (to download artifact from).
+# Streamlit app GitHub user name (to download artifact from).
 ARG GITHUB_USER=OpenMS
-# Streamlit app Gihub repository name (to download artifact from).
+# Streamlit app GitHub repository name (to download artifact from).
 ARG GITHUB_REPO=streamlit-template
 
 USER root

--- a/Dockerfile_simple
+++ b/Dockerfile_simple
@@ -11,9 +11,9 @@ FROM ubuntu:22.04 AS stage1
 ARG OPENMS_REPO=https://github.com/OpenMS/OpenMS.git
 ARG OPENMS_BRANCH=develop
 ARG PORT=8501
-# Streamlit app Gihub user name (to download artifact from).
+# Streamlit app GitHub user name (to download artifact from).
 ARG GITHUB_USER=OpenMS
-# Streamlit app Gihub repository name (to download artifact from).
+# Streamlit app GitHub repository name (to download artifact from).
 ARG GITHUB_REPO=streamlit-template
 
 


### PR DESCRIPTION
Trivial typo fix. Main purpose: smoke-test the registry cache end-to-end on the post-#368 codebase.

## Cache expectations
Only Dockerfile comments changed — buildx strips comments before computing layer hashes, so every layer should be a cache hit:

- **Full variant:** should drop from ~1h8m → a couple of minutes (cache manifest pull + export + kind integration).
- **Simple variant:** should drop from ~9m → well under a minute.

If either variant takes materially longer than that, there's still a cache-busting issue to chase.