### PR TITLE
ci: enable scheduled GHCR cleanup

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,14 +1,14 @@
 name: GHCR Cleanup
 
 on:
-  # schedule:
-  #   - cron: '0 3 * * 0'   # Sundays 03:00 UTC — uncomment in Phase 4
+  schedule:
+    - cron: '0 3 * * 0'   # Sundays 03:00 UTC
   workflow_dispatch:
     inputs:
       dry-run:
         description: 'Dry run (preview deletions without executing)'
         type: boolean
-        default: true
+        default: false
 
 jobs:
   cleanup-app-images:


### PR DESCRIPTION
Phase 4 of the CI refactor. Uncomments the weekly cron in \`ghcr-cleanup.yml\` and flips the manual-dispatch \`dry-run\` default from \`true\` to \`false\`.

- First scheduled run: Sunday 03:00 UTC after merge.
- Dry-run already validated (run [24692746215](https://github.com/OpenMS/streamlit-template/actions/runs/24692746215)) — action resolves, both jobs run to completion, cut-off filter dominates so nothing is flagged for deletion while everything is new.

## Test plan
- [ ] Monitor the first scheduled run's logs. Confirm no \`v*-*\`/\`main-*\`/\`latest\`/\`cache:*\` tags appear in deletion output.
- [ ] If something unexpected is deleted, revert this PR to re-comment the \`schedule:\` block.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automatic cleanup workflow to run weekly on Sundays at 03:00 UTC
  * Updated cleanup task to execute deletions by default instead of performing dry-run previews only

<!-- end of auto-generated comment: release notes by coderabbit.ai -->