### PR TITLE
k8s: mount admin password from streamlit-secrets Secret

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ python*
 gdpr_consent/node_modules/
 *~
 .streamlit/secrets.toml
+k8s/**/streamlit-secrets.yaml
 docs/superpowers/

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -4,6 +4,11 @@ gatherUsageStats = false
 [global]
 developmentMode = false
 
+[secrets]
+# Kubernetes mounts the optional `streamlit-secrets` Secret at /app/admin-secrets/;
+# the default locations are kept so local `streamlit run` picks up ./.streamlit/secrets.toml.
+files = ["/app/admin-secrets/secrets.toml", "~/.streamlit/secrets.toml", ".streamlit/secrets.toml"]
+
 [server]
 address = "0.0.0.0"
 maxUploadSize =  200 #MB

--- a/.streamlit/secrets.toml.example
+++ b/.streamlit/secrets.toml.example
@@ -1,6 +1,10 @@
 # Streamlit Secrets Configuration
 # Copy this file to secrets.toml and fill in your values.
 # IMPORTANT: Never commit secrets.toml to version control!
+#
+# For Kubernetes deployments, do NOT ship this file in the image -- instead
+# mount the password via the `streamlit-secrets` Secret. See
+# docs/kubernetes-deployment.md, "Configuring the admin password".
 
 [admin]
 # Password required to save workspaces as demo workspaces (online mode only)

--- a/docs/kubernetes-deployment.md
+++ b/docs/kubernetes-deployment.md
@@ -142,7 +142,7 @@ Traefik `IngressRoute` CRD. The default rule matches `PathPrefix('/')` (all path
 Lists all base resources under the `openms` namespace.
 
 ### `streamlit-secrets.yaml.example`
-Reference manifest for the optional `streamlit-secrets` Secret consumed by the Streamlit Deployment (mounted at `/app/.streamlit/secrets.toml`, which backs `st.secrets` — currently used for the admin password that gates the "Save as Demo" feature). Intentionally **not** in `k8s/base/kustomization.yaml`: the Secret is created out-of-band so no password is ever committed. See "Configuring the admin password" below.
+Reference manifest for the optional `streamlit-secrets` Secret consumed by the Streamlit Deployment (mounted as a directory at `/app/admin-secrets/`; `.streamlit/config.toml` registers that path under `[secrets].files` so `st.secrets` picks it up — currently used for the admin password that gates the "Save as Demo" feature). Intentionally **not** in `k8s/base/kustomization.yaml`: the Secret is created out-of-band so no password is ever committed. See "Configuring the admin password" below.
 
 ## 4. Fork-and-deploy guide
 

--- a/docs/kubernetes-deployment.md
+++ b/docs/kubernetes-deployment.md
@@ -141,6 +141,9 @@ Traefik `IngressRoute` CRD. The default rule matches `PathPrefix('/')` (all path
 ### `kustomization.yaml`
 Lists all base resources under the `openms` namespace.
 
+### `streamlit-secrets.yaml.example`
+Reference manifest for the optional `streamlit-secrets` Secret consumed by the Streamlit Deployment (mounted at `/app/.streamlit/secrets.toml`, which backs `st.secrets` — currently used for the admin password that gates the "Save as Demo" feature). Intentionally **not** in `k8s/base/kustomization.yaml`: the Secret is created out-of-band so no password is ever committed. See "Configuring the admin password" below.
+
 ## 4. Fork-and-deploy guide
 
 ### Prerequisites
@@ -181,13 +184,50 @@ Open `k8s/overlays/<your-app-name>/kustomization.yaml` and change the following 
 
 The overlay leaves the nginx `Ingress` unpatched because Traefik is the production ingress. If you are deploying to an nginx-only cluster, add an overlay patch for both `rules[].host` entries in the base `Ingress` (same `.de` / `.org` pattern) instead of the IngressRoute patch.
 
-### Step 5 — Deploy
+### Step 5 — Configure the admin password (optional)
+
+Skip this step if you don't need the "Save as Demo" feature. The Streamlit Deployment mounts the `streamlit-secrets` Secret with `optional: true`, so the pod starts either way — the admin UI simply reports "Admin not configured" when the Secret is absent.
+
+**Recommended — imperative, nothing on disk:**
+
+```bash
+kubectl -n openms create secret generic streamlit-secrets \
+  --from-literal=secrets.toml='[admin]
+password = "<your-strong-password>"'
+```
+
+The password never leaves the cluster. Rotate the same way:
+
+```bash
+kubectl -n openms create secret generic streamlit-secrets \
+  --from-literal=secrets.toml='[admin]
+password = "<new-password>"' \
+  --dry-run=client -o yaml | kubectl apply -f -
+kubectl -n openms rollout restart deployment/<your-app-name>-streamlit
+```
+
+Because the Secret is created outside Kustomize, the overlay's `namePrefix` does **not** apply to it — the Deployment references the literal name `streamlit-secrets`, so create it with exactly that name.
+
+**Alternative — manifest in the overlay:**
+
+Copy the template and fill it in:
+
+```bash
+cp k8s/base/streamlit-secrets.yaml.example k8s/overlays/<your-app-name>/streamlit-secrets.yaml
+# edit the password
+```
+
+Add `- streamlit-secrets.yaml` to the `resources:` list in `k8s/overlays/<your-app-name>/kustomization.yaml`. The filename `streamlit-secrets.yaml` is gitignored (`.gitignore`: `k8s/**/streamlit-secrets.yaml`); always confirm with `git status` before committing — never commit a filled-in copy.
+
+When the Secret is managed through Kustomize, the overlay's `namePrefix` rewrites both the Secret name and the Deployment reference, so no manual renaming is needed.
+
+### Step 6 — Deploy
 
 ```bash
 kubectl apply -k k8s/overlays/<your-app-name>/
 ```
 
-### Step 6 — Verify
+### Step 7 — Verify
 
 ```bash
 kubectl -n openms get pods -l app=<your-app-name>

--- a/k8s/base/streamlit-deployment.yaml
+++ b/k8s/base/streamlit-deployment.yaml
@@ -51,8 +51,7 @@ spec:
               subPath: settings-overrides.json
               readOnly: true
             - name: admin-secrets
-              mountPath: /app/.streamlit/secrets.toml
-              subPath: secrets.toml
+              mountPath: /app/admin-secrets
               readOnly: true
           readinessProbe:
             httpGet:
@@ -84,6 +83,3 @@ spec:
           secret:
             secretName: streamlit-secrets
             optional: true
-            items:
-              - key: secrets.toml
-                path: secrets.toml

--- a/k8s/base/streamlit-deployment.yaml
+++ b/k8s/base/streamlit-deployment.yaml
@@ -50,6 +50,10 @@ spec:
               mountPath: /app/settings-overrides.json
               subPath: settings-overrides.json
               readOnly: true
+            - name: admin-secrets
+              mountPath: /app/.streamlit/secrets.toml
+              subPath: secrets.toml
+              readOnly: true
           readinessProbe:
             httpGet:
               path: /_stcore/health
@@ -76,3 +80,10 @@ spec:
         - name: config
           configMap:
             name: streamlit-config
+        - name: admin-secrets
+          secret:
+            secretName: streamlit-secrets
+            optional: true
+            items:
+              - key: secrets.toml
+                path: secrets.toml

--- a/k8s/base/streamlit-secrets.yaml.example
+++ b/k8s/base/streamlit-secrets.yaml.example
@@ -1,0 +1,30 @@
+# EXAMPLE ONLY -- do NOT commit a filled-in copy of this file.
+#
+# This manifest shows the shape of the Secret consumed by the Streamlit
+# Deployment (mounted at /app/.streamlit/secrets.toml via volume
+# `admin-secrets`, which is declared with `optional: true` so the app still
+# runs when this Secret is absent).
+#
+# Recommended path: create the Secret imperatively with
+#
+#   kubectl -n openms create secret generic streamlit-secrets \
+#     --from-literal=secrets.toml='[admin]
+#   password = "<your-strong-password>"'
+#
+# so the password never touches disk outside the cluster. See
+# docs/kubernetes-deployment.md, "Configuring the admin password".
+#
+# Alternative path: copy this file to k8s/overlays/<your-app>/streamlit-secrets.yaml,
+# fill in a real password, and reference it from the overlay's
+# `resources:` list. The filename `streamlit-secrets.yaml` is gitignored,
+# but confirm with `git status` before committing anything.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: streamlit-secrets
+  namespace: openms
+type: Opaque
+stringData:
+  secrets.toml: |
+    [admin]
+    password = "your-secure-admin-password-here"

--- a/k8s/base/streamlit-secrets.yaml.example
+++ b/k8s/base/streamlit-secrets.yaml.example
@@ -1,9 +1,10 @@
 # EXAMPLE ONLY -- do NOT commit a filled-in copy of this file.
 #
 # This manifest shows the shape of the Secret consumed by the Streamlit
-# Deployment (mounted at /app/.streamlit/secrets.toml via volume
+# Deployment (mounted as a directory at /app/admin-secrets/ via volume
 # `admin-secrets`, which is declared with `optional: true` so the app still
-# runs when this Secret is absent).
+# runs when this Secret is absent; `.streamlit/config.toml` registers the
+# path under `[secrets].files` so `st.secrets` picks it up).
 #
 # Recommended path: create the Secret imperatively with
 #

--- a/k8s/overlays/template-app/streamlit-secrets.yaml.example
+++ b/k8s/overlays/template-app/streamlit-secrets.yaml.example
@@ -1,0 +1,38 @@
+# EXAMPLE ONLY -- do NOT commit a filled-in copy of this file.
+#
+# Overlay-level copy of k8s/base/streamlit-secrets.yaml.example for the
+# `template-app` deployment. The Secret is consumed by the Streamlit
+# Deployment (mounted as a directory at /app/admin-secrets/ via volume
+# `admin-secrets`, which is declared with `optional: true` so the app still
+# runs when this Secret is absent; `.streamlit/config.toml` registers the
+# path under `[secrets].files` so `st.secrets` picks it up).
+#
+# Recommended path: create the Secret imperatively so the password never
+# touches disk outside the cluster. Note that the overlay's
+# `namePrefix: template-app-` only applies to resources managed by
+# Kustomize, so an out-of-band Secret must be created with the literal
+# name `streamlit-secrets`:
+#
+#   kubectl -n openms create secret generic streamlit-secrets \
+#     --from-literal=secrets.toml='[admin]
+#   password = "<your-strong-password>"'
+#
+# See docs/kubernetes-deployment.md, "Configuring the admin password".
+#
+# Alternative path: copy this file to streamlit-secrets.yaml in this
+# directory, fill in a real password, and add `- streamlit-secrets.yaml`
+# to the `resources:` list in kustomization.yaml. When managed through
+# Kustomize, `namePrefix` rewrites both the Secret name and the Deployment
+# reference, so no manual renaming is needed. The filename
+# `streamlit-secrets.yaml` is gitignored, but confirm with `git status`
+# before committing anything.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: streamlit-secrets
+  namespace: openms
+type: Opaque
+stringData:
+  secrets.toml: |
+    [admin]
+    password = "your-secure-admin-password-here"


### PR DESCRIPTION
## Summary

- The Save-as-Demo feature reads the admin password from `st.secrets` (i.e. `.streamlit/secrets.toml`), but the Streamlit pod never had that file mounted, so the feature was always disabled on cluster deployments.
- Mount an optional Secret named `streamlit-secrets` as `/app/.streamlit/secrets.toml` in `k8s/base/streamlit-deployment.yaml`. `optional: true` keeps the pod starting when the Secret is absent — the admin UI just shows its existing "Admin not configured" message.
- Ship a reference `k8s/base/streamlit-secrets.yaml.example` manifest (deliberately **not** in `kustomization.yaml` — the Secret is created out-of-band so no password lands in git), gitignore any filled-in `k8s/**/streamlit-secrets.yaml` copy, and document both the imperative `kubectl create secret` flow and the manifest alternative in `docs/kubernetes-deployment.md` (new "Step 5 — Configure the admin password").

No Python changes — existing `src/common/admin.py` already reads `st.secrets["admin"]["password"]` with constant-time compare.

## Test plan

- [ ] `kubectl apply -k k8s/overlays/template-app/` without creating the Secret — pod reaches Ready; "Save as Demo" UI shows "Admin not configured"
- [ ] `kubectl -n openms create secret generic streamlit-secrets --from-literal=secrets.toml='[admin]\npassword = "test"'` then `kubectl rollout restart deployment/template-app-streamlit` — pod re-rolls and `kubectl exec ... -- cat /app/.streamlit/secrets.toml` shows the TOML
- [ ] In-browser: open a workspace → Save as Demo → enter password → confirm new demo workspace appears
- [ ] `kubeconform -strict` passes on `k8s/base/streamlit-deployment.yaml` and on the kustomized `template-app` overlay (already covered by existing `lint-manifests` CI job)
- [ ] Kind integration tests (nginx + Traefik jobs in `.github/workflows/build-and-test.yml`) still green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Kubernetes deployment guide with detailed steps for configuring optional admin passwords using Kubernetes Secrets.

* **Chores**
  * Added infrastructure support for securely managing admin credentials in Kubernetes deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->