### PR TITLE
Support configurable demo workspace source directories

### DIFF
--- a/clean-up-workspaces.py
+++ b/clean-up-workspaces.py
@@ -23,6 +23,9 @@ print(
 remaining_directories = []
 # Iterate through directories in workspaces_directory
 for directory in workspaces_directory.iterdir():
+    # Skip hidden top-level directories (e.g. .demos/ holds seeded demo workspaces)
+    if directory.name.startswith("."):
+        continue
     # Check if it's a directory
     if directory.is_dir():
         # Get the directory's modification time

--- a/docs/kubernetes-deployment.md
+++ b/docs/kubernetes-deployment.md
@@ -107,6 +107,21 @@ PersistentVolumeClaim `workspaces-pvc`:
 - `storageClassName: cinder-csi`
 - `resources.requests.storage: 500Gi`
 
+Demo workspaces live under a hidden `.demos/` subdirectory of this PVC (see [Demo workspaces](#demo-workspaces) below). User workspaces live at the PVC root, one directory per session UUID.
+
+### Demo workspaces
+Demo workspaces are seeded onto the `workspaces-pvc` at `/workspaces-streamlit-template/.demos/` by the `seed-demos` initContainer on the Streamlit Deployment. The init runs `cp -rn /app/example-data/workspaces/. /workspaces-streamlit-template/.demos/` — new demos shipped in an image appear after redeploy, but existing entries on the PV (including admin-saved demos and edits) are preserved.
+
+The ConfigMap override points `demo_workspaces.source_dirs` at `/workspaces-streamlit-template/.demos`, so both Streamlit pods and RQ workers read demos from the PV. The "Save as Demo" admin flow writes to the same path.
+
+To force a re-seed of a specific demo, delete it on the PV and restart the Streamlit Deployment:
+```
+kubectl exec deploy/streamlit -- rm -rf /workspaces-streamlit-template/.demos/<name>
+kubectl rollout restart deploy/streamlit
+```
+
+`clean-up-workspaces.py` skips any top-level directory whose name starts with `.`, so the nightly cleanup cron does not touch `.demos/`.
+
 ### `streamlit-deployment.yaml`
 Main Streamlit Deployment. Key fields:
 - `replicas: 2` (scales to N)
@@ -116,6 +131,7 @@ Main Streamlit Deployment. Key fields:
 - Mounts `settings-overrides.json` from the ConfigMap as a `subPath`
 - Readiness and liveness probes hit `/_stcore/health`
 - Pod affinity: `volume-group: workspaces`
+- `seed-demos` initContainer merges image-shipped demos into `.demos/` on the PVC (see [Demo workspaces](#demo-workspaces))
 
 ### `streamlit-service.yaml`
 ClusterIP Service exposing Streamlit on port 8501.

--- a/k8s/base/configmap.yaml
+++ b/k8s/base/configmap.yaml
@@ -5,5 +5,9 @@ metadata:
 data:
   settings-overrides.json: |
     {
-      "online_deployment": true
+      "online_deployment": true,
+      "demo_workspaces": {
+        "enabled": true,
+        "source_dirs": ["/workspaces-streamlit-template/.demos"]
+      }
     }

--- a/k8s/base/streamlit-deployment.yaml
+++ b/k8s/base/streamlit-deployment.yaml
@@ -25,6 +25,19 @@ spec:
                     values:
                       - workspaces
               topologyKey: kubernetes.io/hostname
+      initContainers:
+        - name: seed-demos
+          image: openms-streamlit
+          imagePullPolicy: Always
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -eu
+              mkdir -p /workspaces-streamlit-template/.demos
+              cp -rn /app/example-data/workspaces/. /workspaces-streamlit-template/.demos/
+          volumeMounts:
+            - name: workspaces
+              mountPath: /workspaces-streamlit-template
       containers:
         - name: streamlit
           image: openms-streamlit

--- a/src/common/admin.py
+++ b/src/common/admin.py
@@ -51,10 +51,25 @@ def get_demo_target_dir() -> Path:
     """
     Get the directory where demo workspaces are stored.
 
+    Reads from settings.demo_workspaces.source_dirs (first entry wins),
+    supporting both the list form and the legacy string form. Falls back
+    to example-data/workspaces when settings are unavailable (e.g. in tests).
+
     Returns:
         Path: The demo workspaces directory.
     """
-    return Path("example-data/workspaces")
+    default = Path("example-data/workspaces")
+    try:
+        demo_config = st.session_state.settings.get("demo_workspaces", {})
+    except (AttributeError, KeyError):
+        return default
+
+    dirs = demo_config.get("source_dirs", demo_config.get("source_dir"))
+    if isinstance(dirs, str):
+        return Path(dirs)
+    if isinstance(dirs, list) and dirs:
+        return Path(dirs[0])
+    return default
 
 
 def demo_exists(demo_name: str) -> bool:


### PR DESCRIPTION
## Summary
This PR adds support for configurable demo workspace source directories, enabling demo workspaces to be seeded and managed on persistent volumes in Kubernetes deployments while maintaining backward compatibility with the default `example-data/workspaces` location.

## Key Changes

- **Updated `get_demo_target_dir()` function** in `src/common/admin.py`:
  - Now reads from `settings.demo_workspaces.source_dirs` configuration
  - Supports both list form (uses first entry) and legacy string form for backward compatibility
  - Falls back to `example-data/workspaces` when settings are unavailable (e.g., in tests)

- **Added `seed-demos` initContainer** to `k8s/base/streamlit-deployment.yaml`:
  - Merges image-shipped demos into `.demos/` subdirectory on the workspaces PVC
  - Uses `cp -rn` to preserve existing entries (admin-saved demos and edits)
  - Runs before main Streamlit container starts

- **Updated ConfigMap** in `k8s/base/configmap.yaml`:
  - Added `demo_workspaces` configuration pointing to `/workspaces-streamlit-template/.demos`
  - Enables demo workspace feature in Kubernetes deployments

- **Updated cleanup script** `clean-up-workspaces.py`:
  - Skips hidden top-level directories (starting with `.`) during nightly cleanup
  - Preserves `.demos/` directory from being cleaned up

- **Added documentation** in `docs/kubernetes-deployment.md`:
  - Explains demo workspace seeding and management on PVC
  - Documents how to force re-seed of specific demos
  - Clarifies interaction with cleanup cron job

## Implementation Details

The solution uses a hidden `.demos/` subdirectory on the PVC to store seeded demo workspaces, separate from user workspaces. This approach:
- Allows demos to be updated via container image redeploys
- Preserves admin-saved demos and modifications on the PV
- Keeps demos isolated from user workspace cleanup operations
- Works consistently across Streamlit pods and RQ workers reading from the same PV location

https://claude.ai/code/session_01Y87aULHSdyBobPdaD4L6tW