### PR TITLE
Remove pod-affinity rules; rely on RWO PVC for co-location

### DIFF
--- a/.claude/skills/configure-k8s-deployment.md
+++ b/.claude/skills/configure-k8s-deployment.md
@@ -29,7 +29,7 @@ Before asking the user anything, read a small known set of files directly (do no
 3. `k8s/base/kustomization.yaml`, `k8s/base/streamlit-deployment.yaml`, `k8s/base/rq-worker-deployment.yaml`, `k8s/base/workspace-pvc.yaml` — confirm the layout still matches the template:
    - PVC `metadata.name` is `workspaces-pvc`.
    - Deployments reference `image: openms-streamlit` (the placeholder Kustomize swaps).
-   - `streamlit-deployment.yaml` has `claimName: workspaces-pvc` and `volume-group: workspaces` (both as a pod label and as the pod-affinity `matchExpressions` value).
+   - `streamlit-deployment.yaml` has `claimName: workspaces-pvc`. (Co-location of the workspace-using pods is enforced by the shared RWO PVC mount, not by a pod-affinity rule.)
 4. `.github/workflows/build-and-test.yml` — confirm which tags CI publishes (the OpenMS template publishes `<branch>-full`, `<branch>-simple`, `<tag>-full`, `<tag>-simple`, plus `latest` on `main`-full pushes).
 
 If any of those files are missing, renamed, or significantly restructured, stop and ask the user how to proceed. Do not pattern-match the standard answers onto an unknown layout.
@@ -155,7 +155,7 @@ spec:
       storage: <size>     # Q6: e.g. 100Gi, 1Ti, 3Ti
 ```
 
-Do **not** rename the PVC, the base `kustomization.yaml` resource list, the `claimName` in `streamlit-deployment.yaml`, or the `volume-group` pod-affinity label. Kustomize's `namePrefix` already gives the in-cluster PVC a unique per-fork name; renaming the base creates a 3-file cascade for no benefit.
+Do **not** rename the PVC, the base `kustomization.yaml` resource list, or the `claimName` in `streamlit-deployment.yaml`. Kustomize's `namePrefix` already gives the in-cluster PVC a unique per-fork name; renaming the base creates a 3-file cascade for no benefit.
 
 Operator caveat (mention in handoff, not your job to verify): in-place expansion of an *already-deployed* PVC requires the StorageClass to have `allowVolumeExpansion: true`. If the operator's `cinder-csi` class does not allow expansion, growing a live PVC requires recreation, not a manifest edit. Resizing on first deploy is unaffected.
 

--- a/docs/kubernetes-deployment.md
+++ b/docs/kubernetes-deployment.md
@@ -35,8 +35,8 @@ Every production OpenMS webapp (quantms-web, umetaflow, FLASHApp) deploys via th
                 │        Streamlit Deployment             │
                 │        (N replicas, default 2)          │
                 │                                         │
-                │   [pod affinity: co-locate with         │
-                │    rq-worker + cleanup-cronjob pods]    │
+                │   [co-located with rq-worker +          │
+                │    cleanup pods via shared RWO PVC]     │
                 └────────┬────────────────────────┬───────┘
                          │ REDIS_URL              │
                          │                        │ /workspaces-...
@@ -76,9 +76,11 @@ Every production OpenMS webapp (quantms-web, umetaflow, FLASHApp) deploys via th
 | Traefik IngressRoute | External HTTP entrypoint with sticky sessions | — | — |
 | nginx Ingress | Alternative HTTP entrypoint used by the CI kind cluster | — | — |
 
-### Pod affinity
+### Pod co-location via the RWO PVC
 
-All workspace-using pods (Streamlit, RQ worker, Cleanup) carry a `volume-group: workspaces` label and a `requiredDuringSchedulingIgnoredDuringExecution` pod-affinity rule keyed on `kubernetes.io/hostname`. This forces every workspace-using pod onto the same node, so they can share the `ReadWriteOnce` PVC.
+All workspace-using pods (Streamlit, RQ worker, Cleanup) of a given fork mount the same `<slug>-workspaces-pvc` (`ReadWriteOnce`, `cinder-csi`). Once the first pod schedules, the volume is attached to that node and the kube-scheduler's `VolumeBinding` plugin pins every subsequent pod that mounts the same PVC to the same node. NodeSelector (`openms.de/memory-tier`) picks which set of nodes the fork is eligible for; the RWO mount picks the specific node within that set.
+
+There is no pod-affinity rule. Forks are isolated from each other — co-location applies within a fork (because they share a PVC), not across forks (each fork has its own PVC).
 
 Co-location is a placement constraint, not a replica cap. The Streamlit deployment can scale to N replicas — they all land on the same node alongside the worker.
 
@@ -130,14 +132,14 @@ Main Streamlit Deployment. Key fields:
 - Mounts the workspace PVC at `/workspaces-streamlit-template`
 - Mounts `settings-overrides.json` from the ConfigMap as a `subPath`
 - Readiness and liveness probes hit `/_stcore/health`
-- Pod affinity: `volume-group: workspaces`
+- Co-located with the RQ worker (and any cleanup Job) on the node the RWO `workspaces-pvc` is attached to
 - `seed-demos` initContainer merges image-shipped demos into `.demos/` on the PVC (see [Demo workspaces](#demo-workspaces))
 
 ### `streamlit-service.yaml`
 ClusterIP Service exposing Streamlit on port 8501.
 
 ### `rq-worker-deployment.yaml`
-RQ worker Deployment (1 replica). Runs `rq worker openms-workflows --url $REDIS_URL`. Shares the workspace PVC via the same `volume-group: workspaces` affinity rule.
+RQ worker Deployment (1 replica). Runs `rq worker openms-workflows --url $REDIS_URL`. Shares the workspace PVC, so it co-locates onto the same node as the Streamlit pods via the RWO mount.
 
 ### `cleanup-cronjob.yaml`
 CronJob that runs `python clean-up-workspaces.py` nightly at 03:00 UTC. Uses `concurrencyPolicy: Forbid`, retains 3 successful and 3 failed jobs. Shares the workspace PVC.

--- a/k8s/base/cleanup-cronjob.yaml
+++ b/k8s/base/cleanup-cronjob.yaml
@@ -15,19 +15,8 @@ spec:
         metadata:
           labels:
             component: cleanup
-            volume-group: workspaces
         spec:
           restartPolicy: OnFailure
-          affinity:
-            podAffinity:
-              requiredDuringSchedulingIgnoredDuringExecution:
-                - labelSelector:
-                    matchExpressions:
-                      - key: volume-group
-                        operator: In
-                        values:
-                          - workspaces
-                  topologyKey: kubernetes.io/hostname
           containers:
             - name: cleanup
               image: openms-streamlit

--- a/k8s/base/rq-worker-deployment.yaml
+++ b/k8s/base/rq-worker-deployment.yaml
@@ -13,18 +13,7 @@ spec:
     metadata:
       labels:
         component: rq-worker
-        volume-group: workspaces
     spec:
-      affinity:
-        podAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: volume-group
-                    operator: In
-                    values:
-                      - workspaces
-              topologyKey: kubernetes.io/hostname
       containers:
         - name: rq-worker
           image: openms-streamlit

--- a/k8s/base/streamlit-deployment.yaml
+++ b/k8s/base/streamlit-deployment.yaml
@@ -13,18 +13,7 @@ spec:
     metadata:
       labels:
         component: streamlit
-        volume-group: workspaces
     spec:
-      affinity:
-        podAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchExpressions:
-                  - key: volume-group
-                    operator: In
-                    values:
-                      - workspaces
-              topologyKey: kubernetes.io/hostname
       initContainers:
         - name: seed-demos
           image: openms-streamlit


### PR DESCRIPTION
## Summary
Simplify pod co-location by removing explicit pod-affinity rules and relying instead on Kubernetes' native `VolumeBinding` scheduler plugin, which automatically pins pods that mount the same `ReadWriteOnce` PVC to the same node.

## Changes
- **Remove pod-affinity rules** from `streamlit-deployment.yaml`, `rq-worker-deployment.yaml`, and `cleanup-cronjob.yaml`
- **Remove `volume-group: workspaces` labels** from all three deployments (no longer needed as affinity selectors)
- **Update documentation** to explain the new co-location mechanism:
  - Pod co-location is now enforced by the shared RWO PVC mount, not by explicit affinity rules
  - Clarify that `NodeSelector` picks the eligible node set, and the RWO mount picks the specific node within that set
  - Emphasize that co-location applies *within* a fork (shared PVC), not *across* forks (each fork has its own PVC)
  - Update deployment descriptions to reference the RWO mount instead of the affinity label
- **Update skill guide** to remove references to the `volume-group` label and pod-affinity rule

## Implementation Details
The Kubernetes scheduler's `VolumeBinding` plugin automatically ensures that once a `ReadWriteOnce` PVC is attached to a node, all subsequent pods mounting that PVC are scheduled to the same node. This eliminates the need for manual pod-affinity configuration while achieving the same co-location guarantee. The change reduces manifest complexity and makes the scheduling constraint more explicit and maintainable.

https://claude.ai/code/session_01HLxsvLLznn5WV42iGHBxiP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Kubernetes deployment documentation to clarify current pod co-location mechanisms.

* **Chores**
  * Simplified Kubernetes configuration by removing deprecated pod affinity constraints from multiple deployment manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->