### PR TITLE
Make CI integration tests discover app slug and hosts dynamically

### DIFF
--- a/.claude/skills/configure-k8s-deployment.md
+++ b/.claude/skills/configure-k8s-deployment.md
@@ -30,7 +30,7 @@ Before asking the user anything, read a small known set of files directly (do no
    - PVC `metadata.name` is `workspaces-pvc`.
    - Deployments reference `image: openms-streamlit` (the placeholder Kustomize swaps).
    - `streamlit-deployment.yaml` has `claimName: workspaces-pvc` and `volume-group: workspaces` (both as a pod label and as the pod-affinity `matchExpressions` value).
-4. `.github/workflows/build-and-test.yml` — confirm which tags CI publishes (the OpenMS template publishes `<branch>-full`, `<branch>-simple`, `<tag>-full`, `<tag>-simple`, plus `latest` on `main`-full pushes).
+4. `.github/workflows/build-and-test.yml` — confirm which tags CI publishes (the OpenMS template publishes `<branch>-full`, `<branch>-simple`, `<tag>-full`, `<tag>-simple`, plus `latest` on `main`-full pushes). Also confirm the `test-nginx` and `test-traefik` jobs derive `SLUG` and `TRAEFIK_HOSTS` from the overlay (look for the `Discover overlay identity` step). If the fork is on an older workflow that hardcodes `template-app` or `template.webapps.openms.*` in `kubectl wait`/curl steps, stop and apply the dynamic-discovery patch from the upstream template before editing the overlay — otherwise the fork's first overlay PR will fail CI on `kubectl wait` returning "no matching resources found" (this is the bug that broke OpenMS/quantms-web PR #19).
 
 If any of those files are missing, renamed, or significantly restructured, stop and ask the user how to proceed. Do not pattern-match the standard answers onto an unknown layout.
 
@@ -164,7 +164,7 @@ Operator caveat (mention in handoff, not your job to verify): in-place expansion
 After committing the edits, tell the user the next steps belong to a human operator (or CI) and are out of scope for you:
 
 1. Open a PR with the overlay edits and have it reviewed.
-2. Merge to `main`. CI (`build-and-test.yml`) rebuilds and pushes the image to GHCR with the tag from Q3.
+2. Merge to `main`. CI (`build-and-test.yml`) rebuilds and pushes the image to GHCR with the tag from Q3. The kind integration jobs (`test-nginx`, `test-traefik`) auto-discover slug and Traefik hostnames from the overlay output, so no workflow edits are needed for fork-specific values.
 3. Cluster operator runs `kubectl apply -k k8s/overlays/prod/` against the OpenMS cluster.
 4. Operator verifies with `kubectl -n openms rollout status deployment/<slug>-streamlit` and a browser check on `https://<sub>.webapps.openms.de`.
 
@@ -185,4 +185,5 @@ After committing the edits, tell the user the next steps belong to a human opera
 - [ ] Redis URL written in both Deployment patches (`streamlit` and `rq-worker`)
 - [ ] Memory-tier component selected
 - [ ] Storage size in `k8s/base/workspace-pvc.yaml` updated only if the user picked a non-default size; PVC name and `claimName` untouched
+- [ ] `.github/workflows/build-and-test.yml` uses dynamic overlay discovery (no `template-app` / `template.webapps.openms.*` literals); patched in if the fork's workflow was on the old hardcoded shape
 - [ ] Changes committed on a feature branch (no PR opened unless the user asked for one)

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -160,19 +160,24 @@ jobs:
             sleep "${i}0"
           done
 
+      - name: Discover overlay identity
+        run: |
+          SLUG=$(yq '.commonLabels.app' k8s/overlays/prod/kustomization.yaml)
+          echo "SLUG=$SLUG" >> "$GITHUB_ENV"
+
       - name: Wait for Redis to be ready
         run: |
-          kubectl wait -n openms --for=condition=ready pod -l app=template-app,component=redis --timeout=60s
+          kubectl wait -n openms --for=condition=ready pod -l app=${SLUG},component=redis --timeout=60s
 
       - name: Verify Redis Service is reachable
         run: |
-          kubectl run redis-test -n openms --image=redis:7-alpine --rm -i --restart=Never -- redis-cli -h template-app-redis.openms.svc.cluster.local ping
+          kubectl run redis-test -n openms --image=redis:7-alpine --rm -i --restart=Never -- redis-cli -h ${SLUG}-redis.openms.svc.cluster.local ping
 
       - name: Verify all deployments are available
         run: |
-          kubectl wait -n openms --for=condition=available deployment -l app=template-app --timeout=180s || true
-          kubectl get pods -n openms -l app=template-app
-          kubectl get services -n openms -l app=template-app
+          kubectl wait -n openms --for=condition=available deployment -l app=${SLUG} --timeout=180s || true
+          kubectl get pods -n openms -l app=${SLUG}
+          kubectl get services -n openms -l app=${SLUG}
 
       - name: Curl both hostnames via nginx ingress
         run: |
@@ -247,29 +252,39 @@ jobs:
             sleep "${i}0"
           done
 
+      - name: Discover overlay identity
+        run: |
+          SLUG=$(yq '.commonLabels.app' k8s/overlays/prod/kustomization.yaml)
+          TRAEFIK_HOSTS=$(kubectl kustomize k8s/overlays/prod/ \
+            | yq 'select(.kind == "IngressRoute") | .spec.routes[0].match' \
+            | grep -oP "Host\(\`\K[^\`]+" | tr '\n' ' ')
+          echo "SLUG=$SLUG" >> "$GITHUB_ENV"
+          echo "TRAEFIK_HOSTS=$TRAEFIK_HOSTS" >> "$GITHUB_ENV"
+
       - name: Wait for Redis to be ready
         run: |
-          kubectl wait -n openms --for=condition=ready pod -l app=template-app,component=redis --timeout=60s
+          kubectl wait -n openms --for=condition=ready pod -l app=${SLUG},component=redis --timeout=60s
 
       - name: Verify all deployments are available
         run: |
-          kubectl wait -n openms --for=condition=available deployment -l app=template-app --timeout=180s || true
-          kubectl get pods -n openms -l app=template-app
-          kubectl get services -n openms -l app=template-app
+          kubectl wait -n openms --for=condition=available deployment -l app=${SLUG} --timeout=180s || true
+          kubectl get pods -n openms -l app=${SLUG}
+          kubectl get services -n openms -l app=${SLUG}
 
       - name: Curl both hostnames via Traefik
         run: |
           kubectl -n traefik port-forward svc/traefik 8080:80 &
           PF_PID=$!
           trap 'kill "$PF_PID" 2>/dev/null || true' EXIT
+          FIRST_HOST=$(echo ${TRAEFIK_HOSTS} | awk '{print $1}')
           for i in $(seq 1 30); do
             sleep 2
-            if curl -fsSo /dev/null --max-time 2 http://127.0.0.1:8080/_stcore/health -H "Host: template.webapps.openms.de"; then
+            if curl -fsSo /dev/null --max-time 2 http://127.0.0.1:8080/_stcore/health -H "Host: ${FIRST_HOST}"; then
               break
             fi
             echo "port-forward / app not ready yet, retry $i"
           done
-          for host in template.webapps.openms.de template.webapps.openms.org; do
+          for host in ${TRAEFIK_HOSTS}; do
             curl -fsS --resolve "$host:8080:127.0.0.1" "http://$host:8080/_stcore/health"
             echo ""
             echo "$host -> 200 OK"


### PR DESCRIPTION
## Summary
Replace hardcoded app identifiers and hostnames in the `test-nginx` and `test-traefik` CI jobs with dynamic discovery from the Kustomize overlay. This allows forks to run integration tests without modifying the workflow file for each new deployment.

## Changes
- **Dynamic slug discovery**: Added `Discover overlay identity` step to both jobs that extracts the app slug from `k8s/overlays/prod/kustomization.yaml` using `yq`
- **Dynamic Traefik hosts**: Extended overlay discovery in `test-traefik` to also extract IngressRoute hostnames from the Kustomize output
- **Replaced hardcoded values**: Updated all `kubectl` commands and curl requests to use `${SLUG}` and `${TRAEFIK_HOSTS}` environment variables instead of `template-app` and `template.webapps.openms.*` literals
- **Updated skill documentation**: Added guidance to the `configure-k8s-deployment.md` skill to check for and apply this dynamic-discovery pattern when reviewing forks, preventing CI failures on overlay PRs

## Implementation Details
- The `test-nginx` job discovers only the slug and uses it for pod/service label selectors and Redis hostname construction
- The `test-traefik` job additionally extracts all IngressRoute hostnames and uses the first one for the initial health check, then iterates over all discovered hosts for full verification
- Both jobs set environment variables that persist across subsequent steps, eliminating the need for workflow edits when deploying new overlays

https://claude.ai/code/session_01HLaYKRCFqJ8SFVLmvqUUeK