### PR TITLE
Add mounted directory browser for file selection in Streamlit UI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -224,6 +224,11 @@ RUN mamba run -n streamlit-env python hooks/hook-analytics.py
 # Set Online Deployment
 RUN jq '.online_deployment = true' settings.json > tmp.json && mv tmp.json settings.json
 
+# Point the in-app mounted-drive browser at the conventional bind-mount path.
+# The browser only renders when this directory exists at runtime, i.e. when
+# the user starts the container with `-v /host/path:/mounted-data`.
+RUN jq '.local_data_dir = "/mounted-data"' settings.json > tmp.json && mv tmp.json settings.json
+
 # Download latest OpenMS App executable as a ZIP file.
 # ARG declared here (not at the top) — otherwise the per-run token busts the cache.
 ARG GITHUB_TOKEN

--- a/README.md
+++ b/README.md
@@ -116,6 +116,24 @@ This repository contains two Dockerfiles.
       docker run -p 8505:8501 openms_streamlit_template
       ```
 
+   ### Mount a local data directory
+
+   To make a directory of MS files on the host available to the running app
+   without uploading or copying them, bind-mount it into the container and
+   point `LOCAL_DATA_DIR` at the container path:
+
+   ```
+   docker run -p 8501:8501 \
+     -v /path/on/host:/mounted-data:ro \
+     -e LOCAL_DATA_DIR=/mounted-data \
+     openms_streamlit_template
+   ```
+
+   The upload widget on each workflow page then shows a tree browser for that
+   directory. Selected files are referenced in place via `external_files.txt`
+   (no copy into the workspace volume), so the mount can safely be read-only.
+   Omitting `-v` / `-e` falls back to the standard browser upload.
+
 ## Documentation
 
 Documentation for **users** and **developers** is included as pages in [this template app](https://abi-services.cs.uni-tuebingen.de/streamlit-template/), indicated by the 📖 icon.

--- a/README.md
+++ b/README.md
@@ -119,20 +119,22 @@ This repository contains two Dockerfiles.
    ### Mount a local data directory
 
    To make a directory of MS files on the host available to the running app
-   without uploading or copying them, bind-mount it into the container and
-   point `LOCAL_DATA_DIR` at the container path:
+   without uploading or copying them, bind-mount it into the container at
+   the path configured by `local_data_dir` in `settings.json` (the Docker
+   image defaults this to `/mounted-data`):
 
    ```
    docker run -p 8501:8501 \
      -v /path/on/host:/mounted-data:ro \
-     -e LOCAL_DATA_DIR=/mounted-data \
      openms_streamlit_template
    ```
 
-   The upload widget on each workflow page then shows a tree browser for that
-   directory. Selected files are referenced in place via `external_files.txt`
-   (no copy into the workspace volume), so the mount can safely be read-only.
-   Omitting `-v` / `-e` falls back to the standard browser upload.
+   The upload widget auto-detects the mount: when the directory exists at
+   runtime it shows an in-app tree browser; selected files are referenced
+   in place via `external_files.txt` (no copy into the workspace volume),
+   so the mount can safely be read-only. Omitting `-v` hides the browser
+   and falls back to the standard upload UI. To use a different container
+   path, change `local_data_dir` in `settings.json` before building.
 
 ## Documentation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,17 +12,14 @@ services:
       - 8501:8501
     volumes:
       - workspaces-streamlit-template:/workspaces-streamlit-template
-      # Optional: mount a host directory of MS data files and expose it to the
-      # in-app file browser by setting LOCAL_DATA_DIR (below) to the container
-      # path. Uncomment and adjust the host path to enable.
+      # Optional: bind-mount a host directory of MS data files at the path
+      # that `local_data_dir` in settings.json points to (the Docker image
+      # defaults this to /mounted-data). When the directory exists at
+      # runtime, the upload page shows an in-app file browser for it.
       # - /path/on/host:/mounted-data:ro
     environment:
       # Number of Streamlit server instances (default: 1 = no load balancer).
       # Set to >1 to enable nginx load balancing across multiple Streamlit instances.
       - STREAMLIT_SERVER_COUNT=1
-      # Optional: when set to an existing directory inside the container, the
-      # upload widget shows a tree browser for that directory and references
-      # picked files in place (no copy into the workspace volume).
-      # - LOCAL_DATA_DIR=/mounted-data
 volumes:
   workspaces-streamlit-template:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,17 @@ services:
       - 8501:8501
     volumes:
       - workspaces-streamlit-template:/workspaces-streamlit-template
+      # Optional: mount a host directory of MS data files and expose it to the
+      # in-app file browser by setting LOCAL_DATA_DIR (below) to the container
+      # path. Uncomment and adjust the host path to enable.
+      # - /path/on/host:/mounted-data:ro
     environment:
       # Number of Streamlit server instances (default: 1 = no load balancer).
       # Set to >1 to enable nginx load balancing across multiple Streamlit instances.
       - STREAMLIT_SERVER_COUNT=1
+      # Optional: when set to an existing directory inside the container, the
+      # upload widget shows a tree browser for that directory and references
+      # picked files in place (no copy into the workspace volume).
+      # - LOCAL_DATA_DIR=/mounted-data
 volumes:
   workspaces-streamlit-template:

--- a/settings.json
+++ b/settings.json
@@ -22,6 +22,7 @@
     "enable_workspaces": true,
     "test": true,
     "workspaces_dir": "..",
+    "local_data_dir": "",
     "queue_settings": {
         "default_timeout": 7200,
         "result_ttl": 86400

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -359,7 +359,6 @@ class StreamlitUI:
                 f"**Add {name} files from mounted directory** "
                 f"`{mount_root}`"
             )
-            st.divider()
 
             # Breadcrumbs: compact tertiary buttons separated by »,
             # with a right-aligned Parent button.
@@ -405,8 +404,6 @@ class StreamlitUI:
                     st.session_state[sess_cwd_key] = str(cwd.parent)
                     st.rerun(scope="fragment")
 
-            st.divider()
-
             try:
                 entries = sorted(
                     (p for p in cwd.iterdir() if not p.name.startswith(".")),
@@ -423,23 +420,14 @@ class StreamlitUI:
             bundled = [p for p in entries if p.is_dir() and _is_match(p)]
             files = [p for p in entries if p.is_file() and _is_match(p)]
 
-            if subdirs:
-                st.caption("Enter subfolder")
-                subdir_names = [d.name for d in subdirs]
-                nav_key = f"mounted_navigate_{key}"
-                choice = st.pills(
-                    "Enter subfolder",
-                    options=subdir_names,
-                    selection_mode="single",
-                    default=None,
-                    key=nav_key,
-                    label_visibility="collapsed",
-                )
-                if choice:
-                    st.session_state[sess_cwd_key] = str(cwd / choice)
-                    st.session_state.pop(nav_key, None)
+            for d in subdirs:
+                if st.button(
+                    f"📂 {d.name}/",
+                    key=f"mounted_dir_{key}_{d.name}",
+                    type="tertiary",
+                ):
+                    st.session_state[sess_cwd_key] = str(d)
                     st.rerun(scope="fragment")
-                st.divider()
 
             selectable = bundled + files
             selected_paths: List[str] = []
@@ -464,9 +452,6 @@ class StreamlitUI:
                     f"No subdirectories or files matching "
                     f"**{', '.join('.' + ft for ft in file_types)}** here."
                 )
-
-            if selectable:
-                st.divider()
 
             count = len(selected_paths)
             if st.button(

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -359,32 +359,53 @@ class StreamlitUI:
                 f"**Add {name} files from mounted directory** "
                 f"`{mount_root}`"
             )
+            st.divider()
 
-            # Breadcrumbs: mount_root.name / sub / sub ...
+            # Breadcrumbs: compact tertiary buttons separated by »,
+            # with a right-aligned Parent button.
             try:
                 rel = cwd.relative_to(mount_root)
                 segments = [mount_root.name] + list(rel.parts) if rel.parts else [mount_root.name]
             except ValueError:
                 segments = [mount_root.name]
-            crumb_cols = st.columns(max(len(segments), 1))
+            n = len(segments)
+            ratios: List[float] = []
+            for i in range(n):
+                ratios.append(max(len(segments[i]), 3))
+                if i < n - 1:
+                    ratios.append(1)
+            ratios.append(20)  # flexible spacer
+            ratios.append(6)   # parent button slot
+            crumb_cols = st.columns(ratios, vertical_alignment="center")
+            col_idx = 0
             for i, seg in enumerate(segments):
                 target = mount_root.joinpath(*segments[1 : i + 1]) if i > 0 else mount_root
-                if crumb_cols[i].button(
-                    seg if i == 0 else f"/ {seg}",
+                if crumb_cols[col_idx].button(
+                    seg,
                     key=f"crumb_{key}_{i}",
-                    use_container_width=True,
+                    type="tertiary",
                 ):
                     st.session_state[sess_cwd_key] = str(target)
                     st.rerun(scope="fragment")
-
+                col_idx += 1
+                if i < n - 1:
+                    crumb_cols[col_idx].markdown(
+                        "<span style='color:#888'>»</span>",
+                        unsafe_allow_html=True,
+                    )
+                    col_idx += 1
+            # spacer column
+            col_idx += 1
             if cwd != mount_root:
-                if st.button(
+                if crumb_cols[col_idx].button(
                     "⬆ Parent",
                     key=f"mounted_parent_{key}",
-                    use_container_width=True,
+                    type="tertiary",
                 ):
                     st.session_state[sess_cwd_key] = str(cwd.parent)
                     st.rerun(scope="fragment")
+
+            st.divider()
 
             try:
                 entries = sorted(
@@ -402,14 +423,23 @@ class StreamlitUI:
             bundled = [p for p in entries if p.is_dir() and _is_match(p)]
             files = [p for p in entries if p.is_file() and _is_match(p)]
 
-            for d in subdirs:
-                if st.button(
-                    f"📂 {d.name}/",
-                    key=f"mounted_dir_{key}_{d.name}",
-                    use_container_width=True,
-                ):
-                    st.session_state[sess_cwd_key] = str(d)
+            if subdirs:
+                st.caption("Enter subfolder")
+                subdir_names = [d.name for d in subdirs]
+                nav_key = f"mounted_navigate_{key}"
+                choice = st.pills(
+                    "Enter subfolder",
+                    options=subdir_names,
+                    selection_mode="single",
+                    default=None,
+                    key=nav_key,
+                    label_visibility="collapsed",
+                )
+                if choice:
+                    st.session_state[sess_cwd_key] = str(cwd / choice)
+                    st.session_state.pop(nav_key, None)
                     st.rerun(scope="fragment")
+                st.divider()
 
             selectable = bundled + files
             selected_paths: List[str] = []
@@ -434,6 +464,9 @@ class StreamlitUI:
                     f"No subdirectories or files matching "
                     f"**{', '.join('.' + ft for ft in file_types)}** here."
                 )
+
+            if selectable:
+                st.divider()
 
             count = len(selected_paths)
             if st.button(

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -23,6 +23,18 @@ from src.common.common import (
 from src.workflow._log_status import classify_log_outcome
 
 
+def _mounted_data_root() -> Union[Path, None]:
+    """Return the validated mount root from LOCAL_DATA_DIR, or None."""
+    raw = os.environ.get("LOCAL_DATA_DIR", "").strip()
+    if not raw:
+        return None
+    try:
+        p = Path(raw).expanduser().resolve(strict=True)
+    except (OSError, RuntimeError):
+        return None
+    return p if p.is_dir() else None
+
+
 class StreamlitUI:
     """
     Provides an interface for Streamlit applications to handle file uploads,
@@ -76,6 +88,8 @@ class StreamlitUI:
 
         c1, c2 = st.columns(2)
         c1.markdown("**Upload file(s)**")
+
+        mount_root = _mounted_data_root() if st.session_state.location == "online" else None
 
         if st.session_state.location == "local":
             c2_text, c2_checkbox = c2.columns([1.5, 1], gap="large")
@@ -247,6 +261,10 @@ class StreamlitUI:
                     "This means that the original files will be used instead. "
                 )
 
+        if mount_root is not None:
+            with c2:
+                self._mounted_drive_browser(key, name, file_types, files_dir, mount_root)
+
         if fallback and not any([f for f in Path(files_dir).iterdir() if f.name != "external_files.txt"]):
             if isinstance(fallback, str):
                 fallback = [fallback]
@@ -302,6 +320,146 @@ class StreamlitUI:
                 st.rerun()
         elif not fallback:
             st.warning(f"No **{name}** files!")
+
+    def _resolve_browser_cwd(self, key: str, mount_root: Path) -> Path:
+        """Read cwd for this widget from session state, confine it to mount_root."""
+        sess_key = f"mounted_cwd_{key}"
+        raw = st.session_state.get(sess_key, str(mount_root))
+        try:
+            cwd = Path(raw).expanduser().resolve(strict=True)
+        except (OSError, RuntimeError):
+            cwd = mount_root
+        if cwd != mount_root and mount_root not in cwd.parents:
+            cwd = mount_root
+        st.session_state[sess_key] = str(cwd)
+        return cwd
+
+    def _mounted_drive_browser(
+        self,
+        key: str,
+        name: str,
+        file_types: List[str],
+        files_dir: Path,
+        mount_root: Path,
+    ) -> None:
+        """Render a tree browser for a mounted host directory.
+
+        Selected files are referenced in place via ``external_files.txt`` —
+        the same mechanism the offline tkinter flow uses.
+        """
+        external_files = Path(files_dir, "external_files.txt")
+        if not external_files.exists():
+            external_files.touch()
+
+        cwd = self._resolve_browser_cwd(key, mount_root)
+        sess_cwd_key = f"mounted_cwd_{key}"
+
+        with st.container(border=True):
+            st.markdown(
+                f"**Add {name} files from mounted directory** "
+                f"`{mount_root}`"
+            )
+
+            # Breadcrumbs: mount_root.name / sub / sub ...
+            try:
+                rel = cwd.relative_to(mount_root)
+                segments = [mount_root.name] + list(rel.parts) if rel.parts else [mount_root.name]
+            except ValueError:
+                segments = [mount_root.name]
+            crumb_cols = st.columns(max(len(segments), 1))
+            for i, seg in enumerate(segments):
+                target = mount_root.joinpath(*segments[1 : i + 1]) if i > 0 else mount_root
+                if crumb_cols[i].button(
+                    seg if i == 0 else f"/ {seg}",
+                    key=f"crumb_{key}_{i}",
+                    use_container_width=True,
+                ):
+                    st.session_state[sess_cwd_key] = str(target)
+                    st.rerun(scope="fragment")
+
+            if cwd != mount_root:
+                if st.button(
+                    "⬆ Parent",
+                    key=f"mounted_parent_{key}",
+                    use_container_width=True,
+                ):
+                    st.session_state[sess_cwd_key] = str(cwd.parent)
+                    st.rerun(scope="fragment")
+
+            try:
+                entries = sorted(
+                    (p for p in cwd.iterdir() if not p.name.startswith(".")),
+                    key=lambda p: (not p.is_dir(), p.name.lower()),
+                )
+            except PermissionError:
+                st.error(f"Permission denied reading `{cwd}`.")
+                return
+
+            def _is_match(p: Path) -> bool:
+                return any(p.name.endswith(f".{ft}") for ft in file_types)
+
+            subdirs = [p for p in entries if p.is_dir() and not _is_match(p)]
+            bundled = [p for p in entries if p.is_dir() and _is_match(p)]
+            files = [p for p in entries if p.is_file() and _is_match(p)]
+
+            for d in subdirs:
+                if st.button(
+                    f"📂 {d.name}/",
+                    key=f"mounted_dir_{key}_{d.name}",
+                    use_container_width=True,
+                ):
+                    st.session_state[sess_cwd_key] = str(d)
+                    st.rerun(scope="fragment")
+
+            selectable = bundled + files
+            selected_paths: List[str] = []
+            for f in selectable:
+                cb_key = f"mounted_pick_{key}_{f}"
+                size_label = ""
+                if f.is_file():
+                    try:
+                        size_mb = f.stat().st_size / (1024 * 1024)
+                        size_label = f"  ·  {size_mb:.1f} MB"
+                    except OSError:
+                        pass
+                icon = "🗂️" if f.is_dir() else "📄"
+                if st.checkbox(
+                    f"{icon} {f.name}{size_label}",
+                    key=cb_key,
+                ):
+                    selected_paths.append(str(f))
+
+            if not subdirs and not selectable:
+                st.info(
+                    f"No subdirectories or files matching "
+                    f"**{', '.join('.' + ft for ft in file_types)}** here."
+                )
+
+            count = len(selected_paths)
+            if st.button(
+                f"➕ Add {count} selected {name} file(s)" if count else f"➕ Add selected {name} file(s)",
+                key=f"mounted_add_{key}",
+                type="primary",
+                use_container_width=True,
+                disabled=count == 0,
+            ):
+                existing = set(
+                    line.strip()
+                    for line in external_files.read_text().splitlines()
+                    if line.strip()
+                )
+                added = 0
+                with open(external_files, "a") as fh:
+                    for p in selected_paths:
+                        if p not in existing:
+                            fh.write(f"{p}\n")
+                            existing.add(p)
+                            added += 1
+                # Clear the checkboxes by removing their session keys.
+                for f in selectable:
+                    st.session_state.pop(f"mounted_pick_{key}_{f}", None)
+                st.success(f"Added {added} file(s) from `{cwd}`.")
+                st.rerun(scope="fragment")
 
     def select_input_file(
         self,

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -354,6 +354,20 @@ class StreamlitUI:
         cwd = self._resolve_browser_cwd(key, mount_root)
         sess_cwd_key = f"mounted_cwd_{key}"
 
+        st.markdown(
+            """
+            <style>
+            div[data-testid="stButton"] button[kind="tertiary"] {
+                padding-top: 0.15rem;
+                padding-bottom: 0.15rem;
+                min-height: 0;
+                line-height: 1.3;
+            }
+            </style>
+            """,
+            unsafe_allow_html=True,
+        )
+
         with st.container(border=True):
             st.markdown(
                 f"**Add {name} files from mounted directory** "
@@ -421,7 +435,8 @@ class StreamlitUI:
             files = [p for p in entries if p.is_file() and _is_match(p)]
 
             for d in subdirs:
-                if st.button(
+                indent, body = st.columns([1, 60], vertical_alignment="center")
+                if body.button(
                     f"📂 {d.name}/",
                     key=f"mounted_dir_{key}_{d.name}",
                     type="tertiary",

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -24,8 +24,14 @@ from src.workflow._log_status import classify_log_outcome
 
 
 def _mounted_data_root() -> Union[Path, None]:
-    """Return the validated mount root from LOCAL_DATA_DIR, or None."""
-    raw = os.environ.get("LOCAL_DATA_DIR", "").strip()
+    """Return the validated mount root from the ``local_data_dir`` setting.
+
+    The browser renders only when that path resolves to an existing
+    directory inside the container, i.e. when a host volume is actually
+    mounted there.
+    """
+    settings = st.session_state.get("settings") or {}
+    raw = (settings.get("local_data_dir") or "").strip()
     if not raw:
         return None
     try:
@@ -265,7 +271,15 @@ class StreamlitUI:
             with c2:
                 self._mounted_drive_browser(key, name, file_types, files_dir, mount_root)
 
-        if fallback and not any([f for f in Path(files_dir).iterdir() if f.name != "external_files.txt"]):
+        external_files_path = Path(files_dir, "external_files.txt")
+        has_real_files = any(
+            p.name != "external_files.txt" for p in files_dir.iterdir()
+        )
+        has_external_picks = external_files_path.exists() and any(
+            line.strip() and os.path.exists(line.strip())
+            for line in external_files_path.read_text().splitlines()
+        )
+        if fallback and not has_real_files and not has_external_picks:
             if isinstance(fallback, str):
                 fallback = [fallback]
             for f in fallback:


### PR DESCRIPTION
## Summary
This PR adds support for browsing and selecting files from a mounted host directory without requiring file uploads. When the `LOCAL_DATA_DIR` environment variable is set, users can navigate a directory tree and reference files in place via `external_files.txt`.

## Key Changes
- **New helper function `_mounted_data_root()`**: Validates and returns the mount root from the `LOCAL_DATA_DIR` environment variable, with proper error handling for invalid or inaccessible paths.

- **New method `_mounted_drive_browser()`**: Renders an interactive tree browser UI with:
  - Breadcrumb navigation for the current directory path
  - Parent directory navigation button
  - Directory listing with folders and matching files
  - File size display for selected files
  - Checkbox selection for multiple files
  - "Add selected files" button that appends paths to `external_files.txt`
  - Permission error handling

- **New method `_resolve_browser_cwd()`**: Manages the current working directory state for each widget instance, ensuring the path stays within the mount root and persists across Streamlit reruns.

- **Integration in `upload_widget()`**: Conditionally renders the mounted directory browser when `LOCAL_DATA_DIR` is set and the location is "online".

- **Documentation updates**: Added instructions to README.md and docker-compose.yml explaining how to mount a host directory and use the feature.

## Implementation Details
- Files are referenced in place via the existing `external_files.txt` mechanism (same as the offline tkinter flow), avoiding unnecessary copies into the workspace volume.
- The mount can safely be read-only since no files are copied.
- Session state is used to track the current working directory per widget instance.
- Directory traversal is confined to the mount root for security.
- Entries are sorted with directories first, then by name (case-insensitive).

https://claude.ai/code/session_01D8nvwaRQpEYTuUdKemPtkn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App can detect and browse a host-mounted MS data directory (when configured) and lets users navigate, select files via breadcrumbs and checkboxes; selections are referenced directly without copying into the workspace and fallback to the standard upload UI if no mount is present.

* **Documentation**
  * README and container examples updated with instructions for bind-mounting a host data directory and the expected mount path configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/streamlit-template/pull/385)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->