### PR TITLE
Support Apptainer/Singularity with read-only root filesystem

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -146,7 +146,12 @@ jobs:
         run: |
           # Default apptainer semantics: read-only root, no --writable-tmpfs.
           # This matches how users on HPC clusters run the SIF.
-          apptainer instance start /tmp/openms.sif openms-test
+          # Use `instance run` (apptainer 1.1+), not `instance start`: the SIF
+          # was built from docker-archive, which populates %runscript with the
+          # Docker ENTRYPOINT but leaves %startscript as the default no-op
+          # `exec "$@"`. `instance start` would launch an empty instance and
+          # streamlit would never bind 8501.
+          apptainer instance run /tmp/openms.sif openms-test
           apptainer instance list
           # Record where this run's logs will land so subsequent steps can tail
           # them deterministically (path depends on hostname/user).

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -111,6 +111,78 @@ jobs:
           path: /tmp/image.tar
           retention-days: 1
 
+  test-apptainer:
+    # Apptainer/Singularity is the dominant container runtime on HPC clusters.
+    # It mounts the root filesystem read-only and runs as the host user's UID
+    # (not root inside the image). The entrypoint must tolerate both: this job
+    # exercises that contract by running the built image under apptainer and
+    # waiting for the streamlit /_stcore/health endpoint to come up.
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [full, simple]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: openms-streamlit-${{ matrix.variant }}-image
+          path: /tmp
+
+      - name: Install apptainer
+        uses: eWaterCycle/setup-apptainer@v2
+        with:
+          apptainer-version: 1.3.4
+
+      - name: Build SIF from docker-archive
+        run: |
+          sudo apptainer build /tmp/openms.sif docker-archive:///tmp/image.tar
+          sudo chmod a+r /tmp/openms.sif
+
+      - name: Start apptainer instance (read-only root, host UID)
+        run: |
+          # Default apptainer semantics: read-only root, no --writable-tmpfs.
+          # This matches how users on HPC clusters run the SIF.
+          apptainer instance start /tmp/openms.sif openms-test
+          apptainer instance list
+
+      - name: Wait for streamlit /_stcore/health
+        run: |
+          for i in $(seq 1 90); do
+            if curl -fsSo /dev/null --max-time 2 http://127.0.0.1:8501/_stcore/health; then
+              echo "Streamlit is ready after $i attempts"
+              exit 0
+            fi
+            echo "Waiting for streamlit... attempt $i"
+            sleep 2
+          done
+          echo "TIMED OUT waiting for streamlit health endpoint"
+          exit 1
+
+      - name: Verify health endpoint returns 200
+        run: curl -fsS http://127.0.0.1:8501/_stcore/health
+
+      - name: Verify Redis is reachable inside container (full variant)
+        if: matrix.variant == 'full'
+        run: |
+          apptainer exec instance://openms-test redis-cli ping | grep -i pong
+
+      - name: Dump entrypoint logs on failure
+        if: failure()
+        run: |
+          echo "--- apptainer instance list ---"
+          apptainer instance list || true
+          echo "--- apptainer instance logs ---"
+          find "$HOME/.apptainer" \( -name '*.out' -o -name '*.err' \) 2>/dev/null \
+            | while read -r f; do echo "=== $f ==="; cat "$f"; done || true
+
+      - name: Stop apptainer instance
+        if: always()
+        run: apptainer instance stop openms-test || true
+
   test-nginx:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -148,18 +148,38 @@ jobs:
           # This matches how users on HPC clusters run the SIF.
           apptainer instance start /tmp/openms.sif openms-test
           apptainer instance list
+          # Record where this run's logs will land so subsequent steps can tail
+          # them deterministically (path depends on hostname/user).
+          LOG_DIR=$(find "$HOME/.apptainer/instances/logs" -type d -name "$(whoami)" 2>/dev/null | head -n 1)
+          echo "APPTAINER_LOG_DIR=${LOG_DIR}" >> "$GITHUB_ENV"
+          ls -la "$LOG_DIR" || true
 
       - name: Wait for streamlit /_stcore/health
         run: |
+          # Tail the entrypoint's stdout/stderr alongside the health probe so
+          # any startup failure surfaces directly in the CI log (the dedicated
+          # "Dump entrypoint logs on failure" step is post-mortem only and
+          # easy to miss in the GH Actions UI).
+          OUT="${APPTAINER_LOG_DIR}/openms-test.out"
+          ERR="${APPTAINER_LOG_DIR}/openms-test.err"
           for i in $(seq 1 90); do
             if curl -fsSo /dev/null --max-time 2 http://127.0.0.1:8501/_stcore/health; then
               echo "Streamlit is ready after $i attempts"
               exit 0
             fi
-            echo "Waiting for streamlit... attempt $i"
+            if [ $((i % 5)) -eq 0 ]; then
+              echo "--- attempt $i: instance log tail ---"
+              tail -n 20 "$OUT" 2>/dev/null || echo "(no $OUT yet)"
+              tail -n 10 "$ERR" 2>/dev/null || echo "(no $ERR yet)"
+              apptainer instance list || true
+            fi
             sleep 2
           done
           echo "TIMED OUT waiting for streamlit health endpoint"
+          echo "--- full entrypoint stdout ---"
+          cat "$OUT" 2>/dev/null || echo "(missing)"
+          echo "--- full entrypoint stderr ---"
+          cat "$ERR" 2>/dev/null || echo "(missing)"
           exit 1
 
       - name: Verify health endpoint returns 200

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,8 +120,12 @@ FROM compile-openms AS run-app
 RUN apt-get update && apt-get install -y --no-install-recommends redis-server nginx \
     && rm -rf /var/lib/apt/lists/*
 
-# Create Redis data directory
-RUN mkdir -p /var/lib/redis && chown redis:redis /var/lib/redis
+# Create Redis data directory. We do NOT chown to redis:redis here: under
+# apptainer/singularity the container runs as the host user's UID (not root,
+# not the in-image redis user), so a redis-owned dir is inaccessible. The
+# entrypoint switches to /tmp/openms-runtime-* when the root FS is read-only;
+# in docker mode the dir just needs to exist and be writable by root.
+RUN mkdir -p /var/lib/redis && chmod 0777 /var/lib/redis
 
 # Create workdir and copy over all streamlit related files/folders.
 
@@ -155,67 +159,10 @@ ENV REDIS_URL=redis://localhost:6379/0
 # Set to >1 to enable nginx load balancer with multiple Streamlit instances
 ENV STREAMLIT_SERVER_COUNT=1
 
-# create entrypoint script to start cron, Redis, RQ workers, and Streamlit
-RUN echo -e '#!/bin/bash\n\
-set -e\n\
-source /root/miniforge3/bin/activate streamlit-env\n\
-\n\
-# Start cron for workspace cleanup\n\
-service cron start\n\
-\n\
-# Start Redis server in background\n\
-echo "Starting Redis server..."\n\
-redis-server --daemonize yes --dir /var/lib/redis --appendonly no\n\
-\n\
-# Wait for Redis to be ready\n\
-until redis-cli ping > /dev/null 2>&1; do\n\
-    echo "Waiting for Redis..."\n\
-    sleep 1\n\
-done\n\
-echo "Redis is ready"\n\
-\n\
-# Start RQ worker(s) in background\n\
-WORKER_COUNT=${RQ_WORKER_COUNT:-1}\n\
-echo "Starting $WORKER_COUNT RQ worker(s)..."\n\
-for i in $(seq 1 $WORKER_COUNT); do\n\
-    rq worker openms-workflows --url $REDIS_URL --name worker-$i &\n\
-done\n\
-\n\
-# Load balancer setup\n\
-SERVER_COUNT=${STREAMLIT_SERVER_COUNT:-1}\n\
-\n\
-if [ "$SERVER_COUNT" -gt 1 ]; then\n\
-    echo "Starting $SERVER_COUNT Streamlit instances with nginx load balancer..."\n\
-\n\
-    # Generate nginx upstream block\n\
-    UPSTREAM_SERVERS=""\n\
-    BASE_PORT=8510\n\
-    for i in $(seq 0 $((SERVER_COUNT - 1))); do\n\
-        PORT=$((BASE_PORT + i))\n\
-        UPSTREAM_SERVERS="${UPSTREAM_SERVERS}        server 127.0.0.1:${PORT};\\n"\n\
-    done\n\
-\n\
-    # Write nginx config\n\
-    mkdir -p /etc/nginx\n\
-    echo -e "worker_processes auto;\\npid /run/nginx.pid;\\n\\nevents {\\n    worker_connections 1024;\\n}\\n\\nhttp {\\n    client_max_body_size 0;\\n\\n    map \\$cookie_stroute \\$route_key {\\n        \\x22\\x22      \\$request_id;\\n        default \\$cookie_stroute;\\n    }\\n\\n    upstream streamlit_backend {\\n        hash \\$route_key consistent;\\n${UPSTREAM_SERVERS}    }\\n\\n    map \\$http_upgrade \\$connection_upgrade {\\n        default upgrade;\\n        \\x27\\x27 close;\\n    }\\n\\n    server {\\n        listen 0.0.0.0:8501;\\n\\n        location / {\\n            proxy_pass http://streamlit_backend;\\n            proxy_http_version 1.1;\\n            proxy_set_header Upgrade \\$http_upgrade;\\n            proxy_set_header Connection \\$connection_upgrade;\\n            proxy_set_header Host \\$host;\\n            proxy_set_header X-Real-IP \\$remote_addr;\\n            proxy_set_header X-Forwarded-For \\$proxy_add_x_forwarded_for;\\n            proxy_set_header X-Forwarded-Proto \\$scheme;\\n            proxy_read_timeout 86400;\\n            proxy_send_timeout 86400;\\n            proxy_buffering off;\\n            add_header Set-Cookie \\x22stroute=\\$route_key; Path=/; HttpOnly; SameSite=Lax\\x22 always;\\n        }\\n    }\\n}" > /etc/nginx/nginx.conf\n\
-\n\
-    # Start Streamlit instances on internal ports\n\
-    for i in $(seq 0 $((SERVER_COUNT - 1))); do\n\
-        PORT=$((BASE_PORT + i))\n\
-        echo "Starting Streamlit instance on port $PORT..."\n\
-        streamlit run app.py --server.port $PORT --server.address 0.0.0.0 &\n\
-    done\n\
-\n\
-    sleep 2\n\
-    echo "Starting nginx load balancer on port 8501..."\n\
-    exec /usr/sbin/nginx -g "daemon off;"\n\
-else\n\
-    # Single instance mode (default) - run Streamlit directly on port 8501\n\
-    echo "Starting Streamlit app..."\n\
-    exec streamlit run app.py --server.address 0.0.0.0\n\
-fi\n\
-' > /app/entrypoint.sh
-# make the script executable
+# Install the apptainer-compatible entrypoint that starts cron (when the root
+# FS is writable), Redis, RQ workers, optional nginx load balancer, and the
+# Streamlit server. The script falls back to /tmp paths under apptainer.
+COPY docker/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 
 # Patch Analytics

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,13 @@ RUN wget -q \
     && rm -f Miniforge3-Linux-x86_64.sh
 RUN mamba --version
 
+# Make /root traversable so the entrypoint can `source
+# /root/miniforge3/bin/activate ...` when the container runs as a non-root
+# user (apptainer/singularity maps the host UID into the container; the
+# default ubuntu /root is 0700 which would block path traversal). +x only,
+# not +r, so the directory listing remains private.
+RUN chmod o+x /root
+
 # Setup mamba environment.
 RUN mamba create -n streamlit-env python=3.10
 RUN echo "mamba activate streamlit-env" >> ~/.bashrc
@@ -120,12 +127,11 @@ FROM compile-openms AS run-app
 RUN apt-get update && apt-get install -y --no-install-recommends redis-server nginx \
     && rm -rf /var/lib/apt/lists/*
 
-# Create Redis data directory. We do NOT chown to redis:redis here: under
-# apptainer/singularity the container runs as the host user's UID (not root,
-# not the in-image redis user), so a redis-owned dir is inaccessible. The
-# entrypoint switches to /tmp/openms-runtime-* when the root FS is read-only;
-# in docker mode the dir just needs to exist and be writable by root.
-RUN mkdir -p /var/lib/redis && chmod 0777 /var/lib/redis
+# Create Redis data directory. Default 0755 root-owned is enough: the docker
+# entrypoint runs as root (can write regardless of mode), and the apptainer
+# entrypoint relocates Redis state to /tmp/openms-runtime-* so this dir is
+# never written under apptainer.
+RUN mkdir -p /var/lib/redis
 
 # Create workdir and copy over all streamlit related files/folders.
 

--- a/Dockerfile_simple
+++ b/Dockerfile_simple
@@ -85,49 +85,10 @@ RUN echo "0 3 * * * /root/miniforge3/envs/streamlit-env/bin/python /app/clean-up
 # Set to >1 to enable nginx load balancer with multiple Streamlit instances
 ENV STREAMLIT_SERVER_COUNT=1
 
-# create entrypoint script to start cron service and launch streamlit app
-RUN echo -e '#!/bin/bash\n\
-set -e\n\
-source /root/miniforge3/bin/activate streamlit-env\n\
-\n\
-# Start cron for workspace cleanup\n\
-service cron start\n\
-\n\
-# Load balancer setup\n\
-SERVER_COUNT=${STREAMLIT_SERVER_COUNT:-1}\n\
-\n\
-if [ "$SERVER_COUNT" -gt 1 ]; then\n\
-    echo "Starting $SERVER_COUNT Streamlit instances with nginx load balancer..."\n\
-\n\
-    # Generate nginx upstream block\n\
-    UPSTREAM_SERVERS=""\n\
-    BASE_PORT=8510\n\
-    for i in $(seq 0 $((SERVER_COUNT - 1))); do\n\
-        PORT=$((BASE_PORT + i))\n\
-        UPSTREAM_SERVERS="${UPSTREAM_SERVERS}        server 127.0.0.1:${PORT};\\n"\n\
-    done\n\
-\n\
-    # Write nginx config\n\
-    mkdir -p /etc/nginx\n\
-    echo -e "worker_processes auto;\\npid /run/nginx.pid;\\n\\nevents {\\n    worker_connections 1024;\\n}\\n\\nhttp {\\n    client_max_body_size 0;\\n\\n    map \\$cookie_stroute \\$route_key {\\n        \\x22\\x22      \\$request_id;\\n        default \\$cookie_stroute;\\n    }\\n\\n    upstream streamlit_backend {\\n        hash \\$route_key consistent;\\n${UPSTREAM_SERVERS}    }\\n\\n    map \\$http_upgrade \\$connection_upgrade {\\n        default upgrade;\\n        \\x27\\x27 close;\\n    }\\n\\n    server {\\n        listen 0.0.0.0:8501;\\n\\n        location / {\\n            proxy_pass http://streamlit_backend;\\n            proxy_http_version 1.1;\\n            proxy_set_header Upgrade \\$http_upgrade;\\n            proxy_set_header Connection \\$connection_upgrade;\\n            proxy_set_header Host \\$host;\\n            proxy_set_header X-Real-IP \\$remote_addr;\\n            proxy_set_header X-Forwarded-For \\$proxy_add_x_forwarded_for;\\n            proxy_set_header X-Forwarded-Proto \\$scheme;\\n            proxy_read_timeout 86400;\\n            proxy_send_timeout 86400;\\n            proxy_buffering off;\\n            add_header Set-Cookie \\x22stroute=\\$route_key; Path=/; HttpOnly; SameSite=Lax\\x22 always;\\n        }\\n    }\\n}" > /etc/nginx/nginx.conf\n\
-\n\
-    # Start Streamlit instances on internal ports\n\
-    for i in $(seq 0 $((SERVER_COUNT - 1))); do\n\
-        PORT=$((BASE_PORT + i))\n\
-        echo "Starting Streamlit instance on port $PORT..."\n\
-        streamlit run app.py --server.port $PORT --server.address 0.0.0.0 &\n\
-    done\n\
-\n\
-    sleep 2\n\
-    echo "Starting nginx load balancer on port 8501..."\n\
-    exec /usr/sbin/nginx -g "daemon off;"\n\
-else\n\
-    # Single instance mode (default) - run Streamlit directly on port 8501\n\
-    echo "Starting Streamlit app..."\n\
-    exec streamlit run app.py --server.address 0.0.0.0\n\
-fi\n\
-' > /app/entrypoint.sh
-# make the script executable
+# Install the apptainer-compatible entrypoint (shared with the full image).
+# The script auto-skips the Redis/RQ section when redis-server is not
+# installed, so it works equally well in the simple variant.
+COPY docker/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh
 
 # Patch Analytics

--- a/Dockerfile_simple
+++ b/Dockerfile_simple
@@ -42,6 +42,13 @@ RUN wget -q \
     && rm -f Miniforge3-Linux-x86_64.sh
 RUN mamba --version
 
+# Make /root traversable so the entrypoint can `source
+# /root/miniforge3/bin/activate ...` when the container runs as a non-root
+# user (apptainer/singularity maps the host UID into the container; the
+# default ubuntu /root is 0700 which would block path traversal). +x only,
+# not +r, so the directory listing remains private.
+RUN chmod o+x /root
+
 # Setup mamba environment.
 RUN mamba create -n streamlit-env python=3.10 
 RUN echo "mamba activate streamlit-env" >> ~/.bashrc

--- a/README.md
+++ b/README.md
@@ -136,6 +136,26 @@ This repository contains two Dockerfiles.
    and falls back to the standard upload UI. To use a different container
    path, change `local_data_dir` in `settings.json` before building.
 
+## 🛰️ Run with Apptainer / Singularity (HPC)
+
+Apptainer (formerly Singularity) is the dominant container runtime on HPC
+clusters. Pull the OCI image from GHCR, convert it to a SIF, and run it as
+your user — no root, no `--writable-tmpfs` required:
+
+```bash
+apptainer pull docker://ghcr.io/openms/streamlit-template:latest
+apptainer run \
+  --bind /path/to/data:/mounted-data:ro \
+  --bind /path/to/workspaces:/workspaces-streamlit-template \
+  streamlit-template_latest.sif
+```
+
+The entrypoint auto-detects the read-only root filesystem (set by apptainer's
+default isolation) and switches its runtime state — Redis data directory,
+nginx config, PID files — to `/tmp/openms-runtime-$$`, which is always
+writable inside an apptainer container. The workspace cleanup cron job is
+skipped in this mode; rerun `clean-up-workspaces.py` manually if needed.
+
 ## Documentation
 
 Documentation for **users** and **developers** is included as pages in [this template app](https://abi-services.cs.uni-tuebingen.de/streamlit-template/), indicated by the 📖 icon.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -12,7 +12,13 @@ set -e
 # `streamlit run app.py` would otherwise resolve against the host's CWD.
 cd /app
 
+# Breadcrumbs — surfaced via apptainer instance .out/.err on failure, harmless
+# in docker mode. Cheap to keep around for ongoing apptainer support.
+echo "entrypoint: uid=$(id -u) gid=$(id -g) cwd=$(pwd) host=$(hostname) tty=$(tty 2>/dev/null || echo none)"
+echo "entrypoint: APPTAINER_NAME=${APPTAINER_NAME:-unset} SINGULARITY_NAME=${SINGULARITY_NAME:-unset} APPTAINER_CONTAINER=${APPTAINER_CONTAINER:-unset}"
+
 source /root/miniforge3/bin/activate streamlit-env
+echo "entrypoint: conda env activated, streamlit=$(command -v streamlit || echo NOT_FOUND)"
 
 # -----------------------------------------------------------------------------
 # Apptainer / read-only root filesystem detection

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -103,6 +103,13 @@ fi
 # -----------------------------------------------------------------------------
 SERVER_COUNT="${STREAMLIT_SERVER_COUNT:-1}"
 
+# Surface a misconfigured opt-in to load balancing — silently downgrading to a
+# single instance has bitten users on the simple image variant where nginx
+# isn't installed.
+if [ "$SERVER_COUNT" -gt 1 ] && ! command -v nginx >/dev/null 2>&1; then
+    echo "WARN: STREAMLIT_SERVER_COUNT=$SERVER_COUNT requested but nginx is not installed (simple image?); falling back to a single instance" >&2
+fi
+
 if [ "$SERVER_COUNT" -gt 1 ] && command -v nginx >/dev/null 2>&1; then
     echo "Starting $SERVER_COUNT Streamlit instances with nginx load balancer..."
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+# Container entrypoint for the OpenMS streamlit template.
+#
+# Works with both Docker (writable root FS, runs as root) and
+# Apptainer/Singularity (read-only root FS, runs as the host user's UID).
+# On HPC clusters apptainer is the dominant runtime; this script makes the
+# image usable there without --writable-tmpfs.
+set -e
+
+source /root/miniforge3/bin/activate streamlit-env
+
+# -----------------------------------------------------------------------------
+# Apptainer / read-only root filesystem detection
+# -----------------------------------------------------------------------------
+# Apptainer sets APPTAINER_NAME (and SINGULARITY_NAME for backwards compat).
+# As a fallback we probe /var/run for writability: docker = writable, apptainer
+# default = read-only. Either signal flips us into "read-only mode".
+if [ -n "${APPTAINER_NAME:-}" ] || [ -n "${SINGULARITY_NAME:-}" ] \
+        || [ -n "${APPTAINER_CONTAINER:-}" ] || [ -n "${SINGULARITY_CONTAINER:-}" ] \
+        || ! ( : > /var/run/.openms-rw-probe ) 2>/dev/null; then
+    READONLY_ROOT=1
+    echo "Detected read-only root filesystem (apptainer/singularity mode)"
+else
+    READONLY_ROOT=0
+    rm -f /var/run/.openms-rw-probe 2>/dev/null || true
+fi
+
+# Pick state paths. In read-only mode we must use /tmp (always tmpfs in
+# apptainer); in docker mode we keep the conventional /var paths so existing
+# docker-compose / k8s deployments are unaffected.
+if [ "$READONLY_ROOT" -eq 1 ]; then
+    RUNTIME_DIR="${OPENMS_RUNTIME_DIR:-/tmp/openms-runtime-$$}"
+    mkdir -p "$RUNTIME_DIR"
+    REDIS_DATA_DIR="$RUNTIME_DIR/redis"
+    REDIS_PID_FILE="$RUNTIME_DIR/redis.pid"
+    NGINX_CONF_DIR="$RUNTIME_DIR/nginx"
+    NGINX_PID_FILE="$RUNTIME_DIR/nginx.pid"
+    mkdir -p "$REDIS_DATA_DIR" "$NGINX_CONF_DIR"
+else
+    RUNTIME_DIR="/var/run"
+    REDIS_DATA_DIR="/var/lib/redis"
+    REDIS_PID_FILE="/var/run/redis.pid"
+    NGINX_CONF_DIR="/etc/nginx"
+    NGINX_PID_FILE="/run/nginx.pid"
+fi
+
+# -----------------------------------------------------------------------------
+# Workspace cleanup cron (best-effort)
+# -----------------------------------------------------------------------------
+# `service cron start` writes /var/run/crond.pid; it cannot work on a read-only
+# root. The cleanup job is optional — workspaces just accumulate until the
+# container is rebuilt, which is acceptable for HPC use cases where users
+# manage their own workspace volumes.
+if [ "$READONLY_ROOT" -eq 0 ]; then
+    service cron start || echo "WARN: cron failed to start; workspace cleanup disabled"
+else
+    echo "Skipping cron (read-only root); run clean-up-workspaces.py manually if needed"
+fi
+
+# -----------------------------------------------------------------------------
+# Redis + RQ workers (only present in the full image)
+# -----------------------------------------------------------------------------
+# The simple image does not install redis-server. Skip the whole queue section
+# when the binary is missing, so this entrypoint can be shared by both images.
+if command -v redis-server >/dev/null 2>&1; then
+    echo "Starting Redis server (data=$REDIS_DATA_DIR)..."
+    redis-server --daemonize yes \
+        --dir "$REDIS_DATA_DIR" \
+        --pidfile "$REDIS_PID_FILE" \
+        --appendonly no
+
+    until redis-cli ping >/dev/null 2>&1; do
+        echo "Waiting for Redis..."
+        sleep 1
+    done
+    echo "Redis is ready"
+
+    WORKER_COUNT="${RQ_WORKER_COUNT:-1}"
+    echo "Starting $WORKER_COUNT RQ worker(s)..."
+    for i in $(seq 1 "$WORKER_COUNT"); do
+        rq worker openms-workflows --url "$REDIS_URL" --name "worker-$i" &
+    done
+fi
+
+# -----------------------------------------------------------------------------
+# Streamlit (single instance or behind nginx load balancer)
+# -----------------------------------------------------------------------------
+SERVER_COUNT="${STREAMLIT_SERVER_COUNT:-1}"
+
+if [ "$SERVER_COUNT" -gt 1 ] && command -v nginx >/dev/null 2>&1; then
+    echo "Starting $SERVER_COUNT Streamlit instances with nginx load balancer..."
+
+    UPSTREAM_SERVERS=""
+    BASE_PORT=8510
+    for i in $(seq 0 $((SERVER_COUNT - 1))); do
+        PORT=$((BASE_PORT + i))
+        UPSTREAM_SERVERS="${UPSTREAM_SERVERS}        server 127.0.0.1:${PORT};
+"
+    done
+
+    NGINX_CONF_FILE="$NGINX_CONF_DIR/nginx.conf"
+    cat > "$NGINX_CONF_FILE" <<NGINX_EOF
+worker_processes auto;
+pid $NGINX_PID_FILE;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    client_max_body_size 0;
+
+    map \$cookie_stroute \$route_key {
+        ""      \$request_id;
+        default \$cookie_stroute;
+    }
+
+    upstream streamlit_backend {
+        hash \$route_key consistent;
+${UPSTREAM_SERVERS}    }
+
+    map \$http_upgrade \$connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
+    server {
+        listen 0.0.0.0:8501;
+
+        location / {
+            proxy_pass http://streamlit_backend;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade \$http_upgrade;
+            proxy_set_header Connection \$connection_upgrade;
+            proxy_set_header Host \$host;
+            proxy_set_header X-Real-IP \$remote_addr;
+            proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto \$scheme;
+            proxy_read_timeout 86400;
+            proxy_send_timeout 86400;
+            proxy_buffering off;
+            add_header Set-Cookie "stroute=\$route_key; Path=/; HttpOnly; SameSite=Lax" always;
+        }
+    }
+}
+NGINX_EOF
+
+    for i in $(seq 0 $((SERVER_COUNT - 1))); do
+        PORT=$((BASE_PORT + i))
+        echo "Starting Streamlit instance on port $PORT..."
+        streamlit run app.py --server.port "$PORT" --server.address 0.0.0.0 &
+    done
+
+    sleep 2
+    echo "Starting nginx load balancer on port 8501..."
+    exec /usr/sbin/nginx -c "$NGINX_CONF_FILE" -g "daemon off;"
+else
+    echo "Starting Streamlit app..."
+    exec streamlit run app.py --server.address 0.0.0.0
+fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -69,11 +69,22 @@ if command -v redis-server >/dev/null 2>&1; then
         --pidfile "$REDIS_PID_FILE" \
         --appendonly no
 
-    until redis-cli ping >/dev/null 2>&1; do
-        echo "Waiting for Redis..."
+    # Bounded wait so a broken redis-server (e.g. port already bound by the
+    # host under apptainer's shared net namespace) fails the container fast
+    # instead of hanging forever and never serving /_stcore/health.
+    REDIS_STARTUP_RETRIES="${REDIS_STARTUP_RETRIES:-30}"
+    for i in $(seq 1 "$REDIS_STARTUP_RETRIES"); do
+        if redis-cli ping >/dev/null 2>&1; then
+            echo "Redis is ready"
+            break
+        fi
+        echo "Waiting for Redis... attempt $i/$REDIS_STARTUP_RETRIES"
         sleep 1
     done
-    echo "Redis is ready"
+    if ! redis-cli ping >/dev/null 2>&1; then
+        echo "ERROR: Redis failed to become ready within ${REDIS_STARTUP_RETRIES}s" >&2
+        exit 1
+    fi
 
     WORKER_COUNT="${RQ_WORKER_COUNT:-1}"
     echo "Starting $WORKER_COUNT RQ worker(s)..."

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -7,6 +7,11 @@
 # image usable there without --writable-tmpfs.
 set -e
 
+# Force the app directory regardless of how the container was invoked.
+# `apptainer instance start` does not always honor the Docker WORKDIR, so
+# `streamlit run app.py` would otherwise resolve against the host's CWD.
+cd /app
+
 source /root/miniforge3/bin/activate streamlit-env
 
 # -----------------------------------------------------------------------------
@@ -166,6 +171,6 @@ NGINX_EOF
     echo "Starting nginx load balancer on port 8501..."
     exec /usr/sbin/nginx -c "$NGINX_CONF_FILE" -g "daemon off;"
 else
-    echo "Starting Streamlit app..."
+    echo "Starting Streamlit app (cwd=$(pwd), uid=$(id -u))..."
     exec streamlit run app.py --server.address 0.0.0.0
 fi


### PR DESCRIPTION
## Summary

Refactor the container entrypoint to support both Docker (writable root FS, runs as root) and Apptainer/Singularity (read-only root FS, runs as host user's UID). This enables the image to run on HPC clusters without requiring `--writable-tmpfs` or special privileges.

## Key Changes

- **Extract entrypoint to standalone script** (`docker/entrypoint.sh`):
  - Auto-detect read-only root filesystem via environment variables (`APPTAINER_NAME`, `SINGULARITY_NAME`, `APPTAINER_CONTAINER`, `SINGULARITY_CONTAINER`) or `/var/run` writability probe
  - Switch runtime state paths (`/var/lib/redis`, `/etc/nginx`, PID files) to `/tmp/openms-runtime-$$` when read-only mode is detected
  - Keep conventional `/var` paths in Docker mode for compatibility with existing deployments
  - Skip cron startup in read-only mode (workspace cleanup must be run manually on HPC)
  - Gracefully handle missing Redis/nginx in the simple image variant via `command -v` checks

- **Update Dockerfile and Dockerfile_simple**:
  - Replace inline entrypoint generation with `COPY docker/entrypoint.sh`
  - Change Redis data directory permissions from `chown redis:redis` to `chmod 0777` (required because Apptainer runs as host user, not the in-image redis user)
  - Add explanatory comments about Apptainer compatibility

- **Add Apptainer CI test** (`.github/workflows/build-and-test.yml`):
  - New `test-apptainer` job that builds a SIF from the docker-archive and runs it under Apptainer with default read-only semantics
  - Verifies Streamlit health endpoint comes up and Redis is reachable (full variant only)
  - Tests both `full` and `simple` image variants
  - Includes failure diagnostics (instance logs)

- **Update README**:
  - Add "Run with Apptainer / Singularity (HPC)" section with usage example
  - Document auto-detection of read-only root and `/tmp` fallback behavior
  - Note that workspace cleanup cron is skipped in HPC mode

## Implementation Details

The entrypoint uses a two-pronged detection strategy:
1. Check for Apptainer/Singularity environment variables (most reliable)
2. Probe `/var/run` writability as fallback (works on any read-only root FS)

This approach is robust across different container runtimes and HPC configurations. The script maintains backward compatibility with existing Docker and Docker Compose deployments while enabling seamless HPC cluster usage.

https://claude.ai/code/session_016bVK9NY7ayzM6Hz44dCSiV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for running the app under Apptainer/Singularity (HPC), including read-only root handling and multi-instance Streamlit support with optional proxying.

* **Bug Fixes**
  * Improved runtime permission handling and entrypoint behavior so services adapt when root is read-only; runtime state falls back to tmp paths when needed.

* **Tests**
  * CI adds jobs that convert images to SIF and validate instances and health/connectivity.

* **Documentation**
  * Added Apptainer/Singularity run instructions and workspace cleanup notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/streamlit-template/pull/387)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->