### PR TITLE
fix(singularity): pre-create /workspaces and /mounted-data so :rw bin…

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -219,6 +219,16 @@ jobs:
           grep -q from-container /tmp/host-workspaces/probe.txt
           # Read-only data mount should also be visible inside the container.
           apptainer exec instance://openms-test grep -q from-host-pretest /mounted-data/sentinel.txt
+          # The mounted-drive browser uses os.path.ismount() to gate
+          # rendering (existence is no longer enough now that the image
+          # pre-creates the dir). Assert the kernel reports both paths as
+          # real mount points so the detection function returns truthy.
+          apptainer exec instance://openms-test python3 -c "
+          import os, sys
+          for p in ('/mounted-data', '/workspaces-streamlit-template'):
+              assert os.path.ismount(p), f'{p} not reported as mount point'
+              print(f'ismount({p}) = True')
+          "
 
       - name: Dump entrypoint logs on failure
         if: failure()

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -142,7 +142,16 @@ jobs:
           sudo apptainer build /tmp/openms.sif docker-archive:///tmp/image.tar
           sudo chmod a+r /tmp/openms.sif
 
-      - name: Start apptainer instance (read-only root, host UID)
+      - name: Prepare host bind dirs (mountpoint contract)
+        run: |
+          # Host paths we'll bind into the SIF. Asserting writability through
+          # singularity's bind machinery requires that the destination paths
+          # exist as real directories in the squashfs (otherwise singularity
+          # silently degrades the bind to read-only via underlay).
+          mkdir -p /tmp/host-workspaces /tmp/host-mounted-data
+          echo "from-host-pretest" > /tmp/host-mounted-data/sentinel.txt
+
+      - name: Start apptainer instance (read-only root, host UID, with binds)
         run: |
           # Default apptainer semantics: read-only root, no --writable-tmpfs.
           # This matches how users on HPC clusters run the SIF.
@@ -151,7 +160,10 @@ jobs:
           # Docker ENTRYPOINT but leaves %startscript as the default no-op
           # `exec "$@"`. `instance start` would launch an empty instance and
           # streamlit would never bind 8501.
-          apptainer instance run /tmp/openms.sif openms-test
+          apptainer instance run \
+            --bind /tmp/host-workspaces:/workspaces-streamlit-template:rw \
+            --bind /tmp/host-mounted-data:/mounted-data:ro \
+            /tmp/openms.sif openms-test
           apptainer instance list
           # Record where this run's logs will land so subsequent steps can tail
           # them deterministically (path depends on hostname/user).
@@ -194,6 +206,19 @@ jobs:
         if: matrix.variant == 'full'
         run: |
           apptainer exec instance://openms-test redis-cli ping | grep -i pong
+
+      - name: Verify bind mount is writable (workspaces) and readable (data)
+        run: |
+          # The whole point of pre-creating /workspaces-streamlit-template
+          # and /mounted-data in the image: singularity now has a real
+          # attach point and `:rw` actually sticks. Without the mkdir,
+          # `apptainer exec ... touch` here would fail with EROFS.
+          apptainer exec instance://openms-test sh -c \
+            'echo from-container > /workspaces-streamlit-template/probe.txt'
+          test -f /tmp/host-workspaces/probe.txt
+          grep -q from-container /tmp/host-workspaces/probe.txt
+          # Read-only data mount should also be visible inside the container.
+          apptainer exec instance://openms-test grep -q from-host-pretest /mounted-data/sentinel.txt
 
       - name: Dump entrypoint logs on failure
         if: failure()

--- a/Dockerfile
+++ b/Dockerfile
@@ -133,6 +133,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends redis-server ng
 # never written under apptainer.
 RUN mkdir -p /var/lib/redis
 
+# Pre-create bind-mount targets so apptainer/singularity has a real attach
+# point. Docker auto-creates missing `-v` targets, but singularity uses a
+# read-only underlay and silently ignores `:rw` when the target isn't a
+# real directory in the SIF — writes then fail with EROFS even though the
+# host bind path is writable. Pre-creating these directories costs one
+# inode each and changes nothing in docker mode (the user's volume mount
+# shadows them).
+RUN mkdir -p /workspaces-streamlit-template /mounted-data
+
 # Create workdir and copy over all streamlit related files/folders.
 
 # note: specifying folder with slash as suffix and repeating the folder name seems important to preserve directory structure

--- a/Dockerfile_simple
+++ b/Dockerfile_simple
@@ -62,6 +62,12 @@ RUN mamba install pip
 RUN python -m pip install --upgrade pip
 RUN python -m pip install -r requirements.txt
 
+# Pre-create bind-mount targets so apptainer/singularity has a real attach
+# point. Docker auto-creates missing `-v` targets, but singularity uses a
+# read-only underlay and silently ignores `:rw` when the target isn't a
+# real directory in the SIF — writes then fail with EROFS even though the
+# host bind path is writable.
+RUN mkdir -p /workspaces-streamlit-template /mounted-data
 
 # create workdir and copy over all streamlit related files/folders
 WORKDIR /app

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -26,9 +26,13 @@ from src.workflow._log_status import classify_log_outcome
 def _mounted_data_root() -> Union[Path, None]:
     """Return the validated mount root from the ``local_data_dir`` setting.
 
-    The browser renders only when that path resolves to an existing
-    directory inside the container, i.e. when a host volume is actually
-    mounted there.
+    The browser renders only when ``local_data_dir`` is an actual mount
+    point inside the container — i.e. the operator passed ``-v`` /
+    ``--bind`` / ``volumeMount`` to attach host data. Existence alone is
+    no longer sufficient because the image now pre-creates the path so
+    apptainer/singularity binds have a real attach target; without
+    ``os.path.ismount`` the browser would render an empty tree for every
+    user who didn't mount anything.
     """
     settings = st.session_state.get("settings") or {}
     raw = (settings.get("local_data_dir") or "").strip()
@@ -38,7 +42,11 @@ def _mounted_data_root() -> Union[Path, None]:
         p = Path(raw).expanduser().resolve(strict=True)
     except (OSError, RuntimeError):
         return None
-    return p if p.is_dir() else None
+    if not p.is_dir():
+        return None
+    if not os.path.ismount(p):
+        return None
+    return p
 
 
 class StreamlitUI:


### PR DESCRIPTION
…ds attach

A user binding host storage onto /workspaces-streamlit-template via singularity hit "[Errno 30] Read-only file system" the moment the app tried to mkdir a workspace, even though they passed `:rw` on the bind.

Root cause: neither Dockerfile creates /workspaces-streamlit-template or /mounted-data. Docker auto-creates missing `-v` mount targets, but singularity uses a read-only underlay when the destination isn't a real directory in the SIF and silently degrades the bind — writes then go to the read-only squashfs and fail with EROFS regardless of the `:rw` flag.

`mkdir -p` both paths in Dockerfile and Dockerfile_simple. Cost: one inode each. Behavior in docker mode is unchanged (a `-v` mount, k8s volumeMount, or compose volume shadows the empty dir). Behavior in singularity-without-bind is unchanged — writes still fail with EROFS, just one frame later in the path (parent in squashfs vs. parent missing entirely); persistent storage still requires a bind.

CI guard: the test-apptainer job now starts the instance with explicit `--bind /tmp/host-workspaces:/workspaces-streamlit-template:rw` and `--bind /tmp/host-mounted-data:/mounted-data:ro`, then exec's into the running instance to write a probe file and asserts it appears on the host with the expected contents (plus a read-side check on the :ro mount). Without the mkdir, the probe write would fail with EROFS and the test would fail closed.