### PR TITLE
Publish prebuilt Apptainer SIFs to GHCR via ORAS

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -259,6 +259,81 @@ jobs:
         if: always()
         run: apptainer instance stop openms-test || true
 
+      - name: Upload validated SIF artifact (push events only)
+        if: success() && github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: openms-streamlit-${{ matrix.variant }}-sif
+          path: /tmp/openms.sif
+          retention-days: 1
+          if-no-files-found: error
+
+  publish-apptainer:
+    # Publish the validated SIF (already health-checked above) to GHCR as an
+    # OCI artifact via ORAS, in a sibling package: ghcr.io/<owner>/<repo>/sif.
+    # Keeping it separate from the docker image package keeps tag lists clean
+    # and lets HPC users `apptainer pull oras://...` without the 5-15 min
+    # on-the-fly OCI->SIF conversion the docker:// path requires.
+    needs: test-apptainer
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [full, simple]
+    steps:
+      - name: Download validated SIF artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: openms-streamlit-${{ matrix.variant }}-sif
+          path: /tmp
+
+      - name: Install apptainer
+        uses: eWaterCycle/setup-apptainer@v2
+        with:
+          apptainer-version: 1.3.4
+
+      - name: Compute SIF tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/sif
+          tags: |
+            type=ref,event=branch,suffix=-${{ matrix.variant }}
+            type=ref,event=tag,suffix=-${{ matrix.variant }}
+            type=sha,prefix=,suffix=-${{ matrix.variant }}
+            type=raw,value=latest,enable=${{ matrix.variant == 'full' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+
+      - name: Log in to GHCR for ORAS push
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # apptainer reads its auth from ~/.apptainer/remote.yaml, NOT from
+          # ~/.docker/config.json — so docker/login-action won't work here.
+          # Login and push must both run as the runner user (no sudo) so they
+          # share the same $HOME and therefore the same auth file.
+          echo "$GHCR_TOKEN" | apptainer registry login \
+            --username "${{ github.actor }}" \
+            --password-stdin \
+            oras://ghcr.io
+
+      - name: Push SIF to each computed tag
+        run: |
+          # `apptainer push` accepts ONE destination per invocation; iterate
+          # over the newline-separated tag list from docker/metadata-action.
+          # tr lowercase is belt-and-braces — metadata-action already
+          # lowercases, but GHCR is strict about case in OCI refs.
+          set -euo pipefail
+          while IFS= read -r tag; do
+            [ -z "$tag" ] && continue
+            tag_lc="$(echo "$tag" | tr '[:upper:]' '[:lower:]')"
+            echo "Pushing SIF to oras://${tag_lc}"
+            apptainer push /tmp/openms.sif "oras://${tag_lc}"
+          done <<< "${{ steps.meta.outputs.tags }}"
+
   test-nginx:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -51,3 +51,29 @@ jobs:
           tag-selection: untagged
           cut-off: 7d
           dry-run: ${{ github.event.inputs.dry-run || 'false' }}
+
+  cleanup-sif-images:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Delete old commit-tagged SIFs (keep semver + main + latest)
+        uses: snok/container-retention-policy@v3.0.1
+        with:
+          account: ${{ github.repository_owner }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-names: ${{ github.event.repository.name }}/sif
+          image-tags: "!v*-full !v*-simple !main-full !main-simple !latest"
+          tag-selection: tagged
+          cut-off: 30d
+          dry-run: ${{ github.event.inputs.dry-run || 'false' }}
+
+      - name: Delete untagged SIF manifests
+        uses: snok/container-retention-policy@v3.0.1
+        with:
+          account: ${{ github.repository_owner }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-names: ${{ github.event.repository.name }}/sif
+          tag-selection: untagged
+          cut-off: 7d
+          dry-run: ${{ github.event.inputs.dry-run || 'false' }}

--- a/README.md
+++ b/README.md
@@ -139,16 +139,24 @@ This repository contains two Dockerfiles.
 ## 🛰️ Run with Apptainer / Singularity (HPC)
 
 Apptainer (formerly Singularity) is the dominant container runtime on HPC
-clusters. Pull the OCI image from GHCR, convert it to a SIF, and run it as
-your user — no root, no `--writable-tmpfs` required:
+clusters. CI publishes prebuilt SIFs to GHCR via ORAS, so you can pull a
+ready-to-run image with no on-the-fly OCI→SIF conversion and run it as your
+user — no root, no `--writable-tmpfs` required:
 
 ```bash
-apptainer pull docker://ghcr.io/openms/streamlit-template:latest
+apptainer pull --name openms-streamlit-template.sif \
+  oras://ghcr.io/openms/streamlit-template/sif:latest
 apptainer run \
   --bind /path/to/data:/mounted-data:ro \
   --bind /path/to/workspaces:/workspaces-streamlit-template \
-  streamlit-template_latest.sif
+  openms-streamlit-template.sif
 ```
+
+Available tags follow the same scheme as the Docker images: `latest`,
+`main-full`, `main-simple`, `v*-full`, `v*-simple`, and per-commit SHAs.
+If a tag hasn't been prebuilt yet (e.g. a PR branch), fall back to on-the-fly
+conversion: `apptainer pull docker://ghcr.io/openms/streamlit-template:<tag>`.
+Requires apptainer 1.1+ or singularity-ce 3.10+ for the `oras://` transport.
 
 The entrypoint auto-detects the read-only root filesystem (set by apptainer's
 default isolation) and switches its runtime state — Redis data directory,


### PR DESCRIPTION
## Summary

Add CI/CD pipeline to publish prebuilt Apptainer SIF (Singularity Image Format) containers to GHCR via ORAS, eliminating the need for HPC users to perform on-the-fly OCI→SIF conversion. This significantly improves startup time and user experience for HPC deployments.

## Key Changes

- **build-and-test.yml**: 
  - Added artifact upload step to save validated SIF files after successful test runs (push events only)
  - Added new `publish-apptainer` job that downloads validated SIFs and pushes them to GHCR as OCI artifacts via ORAS
  - Configured tag strategy matching Docker image scheme: `latest`, `main-{full,simple}`, `v*-{full,simple}`, and per-commit SHAs
  - Implemented apptainer registry login and multi-tag push loop with case normalization

- **ghcr-cleanup.yml**:
  - Added `cleanup-sif-images` job to manage SIF artifact retention
  - Keeps semver tags, main branch tags, and latest; deletes old commit-tagged SIFs after 30 days
  - Removes untagged SIF manifests after 7 days

- **README.md**:
  - Updated Apptainer/Singularity section with new ORAS pull instructions
  - Documented available tag schemes and fallback to on-the-fly conversion for unprebuilt tags
  - Added version requirements (apptainer 1.1+ or singularity-ce 3.10+)
  - Clarified that prebuilt SIFs eliminate the 5-15 minute conversion overhead

## Implementation Details

- SIFs are kept in a separate GHCR package (`ghcr.io/<owner>/<repo>/sif`) to keep tag lists clean and distinct from Docker images
- Artifacts are retained for only 1 day (sufficient for the publish job to consume them)
- ORAS authentication uses apptainer's native `~/.apptainer/remote.yaml` rather than Docker config
- Tag computation uses `docker/metadata-action` for consistency with existing Docker image tagging
- Lowercase conversion is applied to all tags (belt-and-braces, as GHCR is strict about OCI reference casing)

https://claude.ai/code/session_01NumLyfkQ3w3JF3TU8jM1iX