### PR TITLE
Add ARM64 (aarch64) multi-architecture Docker build support

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -111,7 +111,7 @@ jobs:
       - name: Upload image artifact
         uses: actions/upload-artifact@v4
         with:
-          name: openms-streamlit-${{ matrix.variant }}-image
+          name: openms-streamlit-${{ matrix.variant }}-amd64-image
           path: /tmp/image.tar
           retention-days: 1
 
@@ -121,9 +121,9 @@ jobs:
     # under `<ref>-<variant>` by the `create-manifest` job below. The build
     # uses a separate `Dockerfile.arm` / `Dockerfile_simple.arm` that swaps
     # the miniforge installer to aarch64 and (for the full variant) guards
-    # the THIRDPARTY/Linux/aarch64 copy. Apptainer/nginx/traefik integration
-    # tests still run only on the amd64 artifact — those gates do not need
-    # arch duplication right now (HPC consumers of the SIF are amd64).
+    # the THIRDPARTY/Linux/aarch64 copy. The built image is also uploaded as
+    # an artifact so the apptainer / nginx / traefik integration jobs can
+    # exercise the ARM image on a native ARM runner (matrix arch=arm64).
     needs: lint-manifests
     runs-on: ubuntu-24.04-arm
     permissions:
@@ -180,6 +180,7 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           platforms: linux/arm64
+          load: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -189,30 +190,22 @@ jobs:
           build-args: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
 
-      - name: Smoke test the just-pushed arm64 image
-        # PRs build (validates Dockerfile.arm parses + compiles) but don't
-        # push, so there's nothing to pull back on PR events. On push/tag,
-        # pull the just-published image and verify /_stcore/health to catch
-        # entrypoint regressions that wouldn't surface in the build itself.
-        if: github.event_name != 'pull_request'
+      - name: Retag for kind (stable local tag)
         run: |
-          set -euo pipefail
-          IMAGE_REF="${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ github.sha }}-${{ matrix.variant }}-arm64"
-          echo "Smoke-testing $IMAGE_REF"
-          docker pull "$IMAGE_REF"
-          docker run -d --rm --name smoketest -p 8501:8501 "$IMAGE_REF"
-          for i in $(seq 1 90); do
-            if curl -fsSo /dev/null --max-time 2 http://127.0.0.1:8501/_stcore/health; then
-              echo "Streamlit healthy after ${i} attempts"
-              docker stop smoketest
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "ERROR: /_stcore/health never returned 200"
-          docker logs smoketest || true
-          docker stop smoketest || true
-          exit 1
+          # load:true above loaded all meta-action tags into local docker.
+          # Retag the first one to the stable name the kustomize overlay expects.
+          FIRST_TAG=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | head -n 1)
+          docker tag "$FIRST_TAG" openms-streamlit:test
+
+      - name: Save image as tar
+        run: docker save openms-streamlit:test -o /tmp/image.tar
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openms-streamlit-${{ matrix.variant }}-arm64-image
+          path: /tmp/image.tar
+          retention-days: 1
 
   create-manifest:
     # Stitch the per-arch tags into multi-arch manifest lists. The manifest
@@ -282,19 +275,31 @@ jobs:
     # (not root inside the image). The entrypoint must tolerate both: this job
     # exercises that contract by running the built image under apptainer and
     # waiting for the streamlit /_stcore/health endpoint to come up.
-    needs: build-amd64
-    runs-on: ubuntu-latest
+    needs: [build-amd64, build-arm64]
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        variant: [full, simple]
+        include:
+          - variant: full
+            arch: amd64
+            runner: ubuntu-latest
+          - variant: full
+            arch: arm64
+            runner: ubuntu-24.04-arm
+          - variant: simple
+            arch: amd64
+            runner: ubuntu-latest
+          - variant: simple
+            arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
 
       - name: Download image artifact
         uses: actions/download-artifact@v4
         with:
-          name: openms-streamlit-${{ matrix.variant }}-image
+          name: openms-streamlit-${{ matrix.variant }}-${{ matrix.arch }}-image
           path: /tmp
 
       - name: Install apptainer
@@ -424,8 +429,12 @@ jobs:
         if: always()
         run: apptainer instance stop openms-test || true
 
-      - name: Upload validated SIF artifact (push events only)
-        if: success() && github.event_name != 'pull_request'
+      - name: Upload validated SIF artifact (amd64 push events only)
+        # SIF publishing stays amd64-only this iteration (HPC consumers of
+        # the SIF are amd64). The arm64 matrix entry still exercises the
+        # full apptainer contract end-to-end; it just doesn't upload the
+        # resulting SIF for downstream publishing.
+        if: success() && github.event_name != 'pull_request' && matrix.arch == 'amd64'
         uses: actions/upload-artifact@v4
         with:
           name: openms-streamlit-${{ matrix.variant }}-sif
@@ -500,19 +509,31 @@ jobs:
           done <<< "${{ steps.meta.outputs.tags }}"
 
   test-nginx:
-    needs: build-amd64
-    runs-on: ubuntu-latest
+    needs: [build-amd64, build-arm64]
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        variant: [full, simple]
+        include:
+          - variant: full
+            arch: amd64
+            runner: ubuntu-latest
+          - variant: full
+            arch: arm64
+            runner: ubuntu-24.04-arm
+          - variant: simple
+            arch: amd64
+            runner: ubuntu-latest
+          - variant: simple
+            arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
 
       - name: Download image artifact
         uses: actions/download-artifact@v4
         with:
-          name: openms-streamlit-${{ matrix.variant }}-image
+          name: openms-streamlit-${{ matrix.variant }}-${{ matrix.arch }}-image
           path: /tmp
 
       - name: Load image into local docker
@@ -587,19 +608,31 @@ jobs:
           done
 
   test-traefik:
-    needs: build-amd64
-    runs-on: ubuntu-latest
+    needs: [build-amd64, build-arm64]
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
-        variant: [full, simple]
+        include:
+          - variant: full
+            arch: amd64
+            runner: ubuntu-latest
+          - variant: full
+            arch: arm64
+            runner: ubuntu-24.04-arm
+          - variant: simple
+            arch: amd64
+            runner: ubuntu-latest
+          - variant: simple
+            arch: arm64
+            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
 
       - name: Download image artifact
         uses: actions/download-artifact@v4
         with:
-          name: openms-streamlit-${{ matrix.variant }}-image
+          name: openms-streamlit-${{ matrix.variant }}-${{ matrix.arch }}-image
           path: /tmp
 
       - name: Load image into local docker

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -275,24 +275,21 @@ jobs:
     # (not root inside the image). The entrypoint must tolerate both: this job
     # exercises that contract by running the built image under apptainer and
     # waiting for the streamlit /_stcore/health endpoint to come up.
-    needs: [build-amd64, build-arm64]
-    runs-on: ${{ matrix.runner }}
+    #
+    # amd64 only: upstream apptainer does NOT publish arm64 .deb assets
+    # (https://github.com/apptainer/apptainer/releases — every release lists
+    # only `apptainer_<ver>_amd64.deb`), so eWaterCycle/setup-apptainer fails
+    # on ubuntu-24.04-arm with "sudo exit code 100" when its
+    # `apt-get install ./apptainer_*.deb` resolves a non-existent package.
+    # Building apptainer from source on the arm runner would add ~15 min and
+    # significant maintenance surface for limited value (HPC SIF consumers
+    # remain amd64). Re-evaluate if upstream starts publishing arm64 builds.
+    needs: build-amd64
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - variant: full
-            arch: amd64
-            runner: ubuntu-latest
-          - variant: full
-            arch: arm64
-            runner: ubuntu-24.04-arm
-          - variant: simple
-            arch: amd64
-            runner: ubuntu-latest
-          - variant: simple
-            arch: arm64
-            runner: ubuntu-24.04-arm
+        variant: [full, simple]
     steps:
       - uses: actions/checkout@v4
 
@@ -309,7 +306,7 @@ jobs:
       - name: Download image artifact
         uses: actions/download-artifact@v4
         with:
-          name: openms-streamlit-${{ matrix.variant }}-${{ matrix.arch }}-image
+          name: openms-streamlit-${{ matrix.variant }}-amd64-image
           path: /tmp
 
       - name: Install apptainer
@@ -439,12 +436,8 @@ jobs:
         if: always()
         run: apptainer instance stop openms-test || true
 
-      - name: Upload validated SIF artifact (amd64 push events only)
-        # SIF publishing stays amd64-only this iteration (HPC consumers of
-        # the SIF are amd64). The arm64 matrix entry still exercises the
-        # full apptainer contract end-to-end; it just doesn't upload the
-        # resulting SIF for downstream publishing.
-        if: success() && github.event_name != 'pull_request' && matrix.arch == 'amd64'
+      - name: Upload validated SIF artifact (push events only)
+        if: success() && github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: openms-streamlit-${{ matrix.variant }}-sif

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -626,6 +626,27 @@ jobs:
             echo "$host -> 200 OK"
           done
 
+      - name: Dump cluster state on failure
+        if: failure()
+        run: |
+          echo "=== nodes ==="
+          kubectl get nodes -o wide || true
+          echo "=== pods (all namespaces) ==="
+          kubectl get pods -A -o wide || true
+          echo "=== app pods describe ==="
+          kubectl describe pod -n openms -l app=${SLUG} || true
+          echo "=== app pod logs ==="
+          kubectl logs -n openms -l app=${SLUG} --tail=200 --all-containers --prefix || true
+          echo "=== app pod previous logs (if crashed) ==="
+          kubectl logs -n openms -l app=${SLUG} --tail=200 --all-containers --prefix --previous || true
+          echo "=== ingress ==="
+          kubectl get ingress -A -o wide || true
+          kubectl describe ingress -n openms || true
+          echo "=== services + endpoints ==="
+          kubectl get svc,endpoints -n openms || true
+          echo "=== ingress-nginx controller logs ==="
+          kubectl logs -n ingress-nginx -l app.kubernetes.io/component=controller --tail=200 || true
+
   test-traefik:
     needs: [build-amd64, build-arm64]
     runs-on: ${{ matrix.runner }}
@@ -741,3 +762,23 @@ jobs:
             echo ""
             echo "$host -> 200 OK"
           done
+
+      - name: Dump cluster state on failure
+        if: failure()
+        run: |
+          echo "=== nodes ==="
+          kubectl get nodes -o wide || true
+          echo "=== pods (all namespaces) ==="
+          kubectl get pods -A -o wide || true
+          echo "=== app pods describe ==="
+          kubectl describe pod -n openms -l app=${SLUG} || true
+          echo "=== app pod logs ==="
+          kubectl logs -n openms -l app=${SLUG} --tail=200 --all-containers --prefix || true
+          echo "=== app pod previous logs (if crashed) ==="
+          kubectl logs -n openms -l app=${SLUG} --tail=200 --all-containers --prefix --previous || true
+          echo "=== traefik ingressroute ==="
+          kubectl get ingressroute -A -o yaml || true
+          echo "=== services + endpoints ==="
+          kubectl get svc,endpoints -n openms || true
+          echo "=== traefik controller logs ==="
+          kubectl logs -n traefik -l app.kubernetes.io/name=traefik --tail=200 || true

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -296,6 +296,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Free disk space
+        # ubuntu-latest has ~14 GB free; the full image (5-8 GB) plus kind
+        # node image plus loading the OCI tar into both docker and kind can
+        # exhaust it. The arm runner is even tighter. Same incantation as
+        # `build-arm64`'s "Free disk space" step.
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache || true
+          sudo apt-get clean
+          df -h
+
       - name: Download image artifact
         uses: actions/download-artifact@v4
         with:
@@ -530,6 +540,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Free disk space
+        # ubuntu-latest has ~14 GB free; the full image (5-8 GB) plus kind
+        # node image plus loading the OCI tar into both docker and kind can
+        # exhaust it. The arm runner is even tighter. Same incantation as
+        # `build-arm64`'s "Free disk space" step.
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache || true
+          sudo apt-get clean
+          df -h
+
       - name: Download image artifact
         uses: actions/download-artifact@v4
         with:
@@ -628,6 +648,16 @@ jobs:
             runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
+
+      - name: Free disk space
+        # ubuntu-latest has ~14 GB free; the full image (5-8 GB) plus kind
+        # node image plus loading the OCI tar into both docker and kind can
+        # exhaust it. The arm runner is even tighter. Same incantation as
+        # `build-arm64`'s "Free disk space" step.
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache || true
+          sudo apt-get clean
+          df -h
 
       - name: Download image artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,7 +38,10 @@ jobs:
           kubectl kustomize k8s/overlays/prod/ | \
             kubeconform -summary -strict -kubernetes-version 1.28.0 -skip IngressRoute
 
-  build:
+  build-amd64:
+    # amd64 path. Produces per-arch tags `<ref>-<variant>-amd64`; the
+    # multi-arch manifest under `<ref>-<variant>` (and `latest`) is stitched
+    # together in `create-manifest` once the sibling `build-arm64` succeeds.
     needs: lint-manifests
     runs-on: ubuntu-latest
     permissions:
@@ -75,22 +78,23 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch,suffix=-${{ matrix.variant }}
-            type=ref,event=tag,suffix=-${{ matrix.variant }}
-            type=sha,prefix=,suffix=-${{ matrix.variant }}
-            type=raw,value=latest,enable=${{ matrix.variant == 'full' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            type=ref,event=branch,suffix=-${{ matrix.variant }}-amd64
+            type=ref,event=tag,suffix=-${{ matrix.variant }}-amd64
+            type=sha,prefix=,suffix=-${{ matrix.variant }}-amd64
+            type=raw,value=latest-amd64,enable=${{ matrix.variant == 'full' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Build and conditionally push
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ${{ matrix.dockerfile }}
+          platforms: linux/amd64
           load: true
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}/cache:${{ matrix.variant }}
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}/cache:{2},mode=max', env.REGISTRY, env.IMAGE_NAME_LC, matrix.variant) || '' }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}/cache:${{ matrix.variant }}-amd64
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}/cache:{2}-amd64,mode=max', env.REGISTRY, env.IMAGE_NAME_LC, matrix.variant) || '' }}
           build-args: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
 
@@ -111,13 +115,174 @@ jobs:
           path: /tmp/image.tar
           retention-days: 1
 
+  build-arm64:
+    # arm64 path. Runs on a native ARM64 runner (no QEMU). Produces per-arch
+    # tags `<ref>-<variant>-arm64`; gets merged into the multi-arch manifest
+    # under `<ref>-<variant>` by the `create-manifest` job below. The build
+    # uses a separate `Dockerfile.arm` / `Dockerfile_simple.arm` that swaps
+    # the miniforge installer to aarch64 and (for the full variant) guards
+    # the THIRDPARTY/Linux/aarch64 copy. Apptainer/nginx/traefik integration
+    # tests still run only on the amd64 artifact — those gates do not need
+    # arch duplication right now (HPC consumers of the SIF are amd64).
+    needs: lint-manifests
+    runs-on: ubuntu-24.04-arm
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: full
+            dockerfile: Dockerfile.arm
+          - variant: simple
+            dockerfile: Dockerfile_simple.arm
+    steps:
+      - name: Free disk space
+        # OpenMS source build needs ~25 GB of scratch space; the ARM runner
+        # image is tighter than the AMD one out of the box. Mirrors what
+        # FLASHApp's publish-docker-images.yml does at the top of its ARM job.
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache || true
+          sudo apt-get clean
+          df -h
+
+      - uses: actions/checkout@v4
+
+      - name: Compute lowercase image name (OCI refs must be lowercase)
+        run: echo "IMAGE_NAME_LC=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch,suffix=-${{ matrix.variant }}-arm64
+            type=ref,event=tag,suffix=-${{ matrix.variant }}-arm64
+            type=sha,prefix=,suffix=-${{ matrix.variant }}-arm64
+            type=raw,value=latest-arm64,enable=${{ matrix.variant == 'full' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+
+      - name: Build and conditionally push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}/cache:${{ matrix.variant }}-arm64
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}/cache:{2}-arm64,mode=max', env.REGISTRY, env.IMAGE_NAME_LC, matrix.variant) || '' }}
+          provenance: false
+          build-args: |
+            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+
+      - name: Smoke test the just-pushed arm64 image
+        # PRs build (validates Dockerfile.arm parses + compiles) but don't
+        # push, so there's nothing to pull back on PR events. On push/tag,
+        # pull the just-published image and verify /_stcore/health to catch
+        # entrypoint regressions that wouldn't surface in the build itself.
+        if: github.event_name != 'pull_request'
+        run: |
+          set -euo pipefail
+          IMAGE_REF="${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:${{ github.sha }}-${{ matrix.variant }}-arm64"
+          echo "Smoke-testing $IMAGE_REF"
+          docker pull "$IMAGE_REF"
+          docker run -d --rm --name smoketest -p 8501:8501 "$IMAGE_REF"
+          for i in $(seq 1 90); do
+            if curl -fsSo /dev/null --max-time 2 http://127.0.0.1:8501/_stcore/health; then
+              echo "Streamlit healthy after ${i} attempts"
+              docker stop smoketest
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "ERROR: /_stcore/health never returned 200"
+          docker logs smoketest || true
+          docker stop smoketest || true
+          exit 1
+
+  create-manifest:
+    # Stitch the per-arch tags into multi-arch manifest lists. The manifest
+    # tags reuse the OLD scheme (`<ref>-<variant>`, `latest`) so existing
+    # consumers (k8s overlays, docker-compose users, `docker pull` callers)
+    # keep working transparently — docker now auto-selects the right arch
+    # on pull. PRs don't push per-arch tags, so there's nothing to merge.
+    needs: [build-amd64, build-arm64]
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        variant: [full, simple]
+    steps:
+      - name: Compute lowercase image name
+        run: echo "IMAGE_NAME_LC=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute manifest tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # NB: no -amd64/-arm64 suffix here. These are the multi-arch
+          # manifest names; they must match the pre-arm64 tag scheme so
+          # `:main-full`, `:v1.0.0-full`, `:latest` continue to resolve.
+          tags: |
+            type=ref,event=branch,suffix=-${{ matrix.variant }}
+            type=ref,event=tag,suffix=-${{ matrix.variant }}
+            type=sha,prefix=,suffix=-${{ matrix.variant }}
+            type=raw,value=latest,enable=${{ matrix.variant == 'full' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+
+      - name: Create and push multi-arch manifests
+        # Iterate over manifest tags (newline-separated from metadata-action)
+        # and merge the matching `-amd64` / `-arm64` per-arch tags into each.
+        # `--amend` makes the step idempotent across workflow_dispatch reruns.
+        # `docker manifest push` accepts only one ref per invocation, hence
+        # the loop.
+        run: |
+          set -euo pipefail
+          while IFS= read -r manifest_tag; do
+            [ -z "$manifest_tag" ] && continue
+            amd_tag="${manifest_tag}-amd64"
+            arm_tag="${manifest_tag}-arm64"
+            echo "Creating manifest ${manifest_tag} from:"
+            echo "  amd: ${amd_tag}"
+            echo "  arm: ${arm_tag}"
+            docker manifest create "$manifest_tag" \
+              --amend "$amd_tag" \
+              --amend "$arm_tag"
+            docker manifest push "$manifest_tag"
+          done <<< "${{ steps.meta.outputs.tags }}"
+
   test-apptainer:
     # Apptainer/Singularity is the dominant container runtime on HPC clusters.
     # It mounts the root filesystem read-only and runs as the host user's UID
     # (not root inside the image). The entrypoint must tolerate both: this job
     # exercises that contract by running the built image under apptainer and
     # waiting for the streamlit /_stcore/health endpoint to come up.
-    needs: build
+    needs: build-amd64
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -335,7 +500,7 @@ jobs:
           done <<< "${{ steps.meta.outputs.tags }}"
 
   test-nginx:
-    needs: build
+    needs: build-amd64
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -422,7 +587,7 @@ jobs:
           done
 
   test-traefik:
-    needs: build
+    needs: build-amd64
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -98,15 +98,17 @@ jobs:
           build-args: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
 
-      - name: Retag for kind (stable local tag)
+      - name: Retag for kind (image name the kustomize overlay points at)
         run: |
-          # load:true above loaded all meta-action tags into local docker.
-          # Retag the first one to the stable name the kustomize overlay expects.
+          # The prod overlay sets `newName: ghcr.io/openms/streamlit-template`,
+          # `newTag: main-full`. The rendered manifests reference that exact
+          # ref, so we need it loaded into kind under that name. Tag invariant
+          # across branches/variants so the test always works.
           FIRST_TAG=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | head -n 1)
-          docker tag "$FIRST_TAG" openms-streamlit:test
+          docker tag "$FIRST_TAG" ghcr.io/openms/streamlit-template:main-full
 
       - name: Save image as tar
-        run: docker save openms-streamlit:test -o /tmp/image.tar
+        run: docker save ghcr.io/openms/streamlit-template:main-full -o /tmp/image.tar
 
       - name: Upload image artifact
         uses: actions/upload-artifact@v4
@@ -192,15 +194,17 @@ jobs:
           build-args: |
             GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
 
-      - name: Retag for kind (stable local tag)
+      - name: Retag for kind (image name the kustomize overlay points at)
         run: |
-          # load:true above loaded all meta-action tags into local docker.
-          # Retag the first one to the stable name the kustomize overlay expects.
+          # The prod overlay sets `newName: ghcr.io/openms/streamlit-template`,
+          # `newTag: main-full`. The rendered manifests reference that exact
+          # ref, so we need it loaded into kind under that name. Tag invariant
+          # across branches/variants so the test always works.
           FIRST_TAG=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | head -n 1)
-          docker tag "$FIRST_TAG" openms-streamlit:test
+          docker tag "$FIRST_TAG" ghcr.io/openms/streamlit-template:main-full
 
       - name: Save image as tar
-        run: docker save openms-streamlit:test -o /tmp/image.tar
+        run: docker save ghcr.io/openms/streamlit-template:main-full -o /tmp/image.tar
 
       - name: Upload image artifact
         uses: actions/upload-artifact@v4
@@ -580,7 +584,7 @@ jobs:
           # Filter out Traefik IngressRoute (kind cluster uses nginx) and force imagePullPolicy=Never
           kubectl kustomize k8s/overlays/prod/ | \
             yq 'select(.kind != "IngressRoute")' | \
-            sed 's|imagePullPolicy: IfNotPresent|imagePullPolicy: Never|g' | \
+            sed -E 's|imagePullPolicy: (IfNotPresent\|Always)|imagePullPolicy: Never|g' | \
             sed 's|storageClassName: cinder-csi|storageClassName: standard|g' > /tmp/manifests.yaml
           for i in 1 2 3 4 5; do
             if kubectl apply -f /tmp/manifests.yaml; then
@@ -720,7 +724,7 @@ jobs:
       - name: Deploy with Kustomize (full manifests, no filter)
         run: |
           kubectl kustomize k8s/overlays/prod/ | \
-            sed 's|imagePullPolicy: IfNotPresent|imagePullPolicy: Never|g' | \
+            sed -E 's|imagePullPolicy: (IfNotPresent\|Always)|imagePullPolicy: Never|g' | \
             sed 's|storageClassName: cinder-csi|storageClassName: standard|g' > /tmp/manifests.yaml
           for i in 1 2 3 4 5; do
             if kubectl apply -f /tmp/manifests.yaml; then

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -143,7 +143,9 @@ jobs:
         # image is tighter than the AMD one out of the box. Mirrors what
         # FLASHApp's publish-docker-images.yml does at the top of its ARM job.
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache || true
+          # Keep /opt/hostedtoolcache: helm/kind-action and setup-kubectl
+          # cache binaries there and fail if the directory is missing.
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc || true
           sudo apt-get clean
           df -h
 
@@ -299,7 +301,9 @@ jobs:
         # exhaust it. The arm runner is even tighter. Same incantation as
         # `build-arm64`'s "Free disk space" step.
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache || true
+          # Keep /opt/hostedtoolcache: helm/kind-action and setup-kubectl
+          # cache binaries there and fail if the directory is missing.
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc || true
           sudo apt-get clean
           df -h
 
@@ -539,7 +543,9 @@ jobs:
         # exhaust it. The arm runner is even tighter. Same incantation as
         # `build-arm64`'s "Free disk space" step.
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache || true
+          # Keep /opt/hostedtoolcache: helm/kind-action and setup-kubectl
+          # cache binaries there and fail if the directory is missing.
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc || true
           sudo apt-get clean
           df -h
 
@@ -648,7 +654,9 @@ jobs:
         # exhaust it. The arm runner is even tighter. Same incantation as
         # `build-arm64`'s "Free disk space" step.
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache || true
+          # Keep /opt/hostedtoolcache: helm/kind-action and setup-kubectl
+          # cache binaries there and fail if the directory is missing.
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc || true
           sudo apt-get clean
           df -h
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -555,9 +555,6 @@ jobs:
           name: openms-streamlit-${{ matrix.variant }}-${{ matrix.arch }}-image
           path: /tmp
 
-      - name: Load image into local docker
-        run: docker load -i /tmp/image.tar
-
       - name: Create kind cluster
         uses: helm/kind-action@v1
         with:
@@ -565,7 +562,13 @@ jobs:
           config: .github/kind-config.yaml
 
       - name: Load image into kind cluster
-        run: kind load docker-image openms-streamlit:test --name test-cluster
+        # Use `kind load image-archive` (not docker-image) so we never store
+        # the image in host docker. Saves ~5-8 GB on /var/lib/docker. Delete
+        # the tar afterwards to free the same again on /tmp — the image is
+        # now in both kind nodes' containerd, which is enough.
+        run: |
+          kind load image-archive /tmp/image.tar --name test-cluster
+          rm -f /tmp/image.tar
 
       - name: Install nginx ingress controller
         run: |
@@ -687,9 +690,6 @@ jobs:
           name: openms-streamlit-${{ matrix.variant }}-${{ matrix.arch }}-image
           path: /tmp
 
-      - name: Load image into local docker
-        run: docker load -i /tmp/image.tar
-
       - name: Create kind cluster
         uses: helm/kind-action@v1
         with:
@@ -697,7 +697,13 @@ jobs:
           config: .github/kind-config.yaml
 
       - name: Load image into kind cluster
-        run: kind load docker-image openms-streamlit:test --name traefik-test
+        # Use `kind load image-archive` (not docker-image) so we never store
+        # the image in host docker. Saves ~5-8 GB on /var/lib/docker. Delete
+        # the tar afterwards to free the same again on /tmp — the image is
+        # now in both kind nodes' containerd, which is enough.
+        run: |
+          kind load image-archive /tmp/image.tar --name traefik-test
+          rm -f /tmp/image.tar
 
       - name: Set up Helm
         uses: azure/setup-helm@v4

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -108,7 +108,16 @@ RUN cmake -DPYOPENMS=ON -DPY_MEMLEAK_DISABLE=On -DCMAKE_IGNORE_PREFIX_PATH=/root
 
 # Build TOPP tools and clean up.
 RUN make -j4 TOPP
-RUN rm -rf src doc CMakeFiles
+# NOTE: do NOT delete CMakeFiles/ here. The two-pass cmake configure used
+# above generates CMakeFiles/VerifyGlobs.cmake for the pyOpenMS targets'
+# CONFIGURE_DEPENDS globs; the next `make -j4 pyopenms` runs
+# `cmake_check_build_system` which fails fast if VerifyGlobs.cmake is gone:
+#   CMake Error: Not a file: /openms-build/CMakeFiles/VerifyGlobs.cmake
+# The x86 single-pass build seems to avoid generating that file (different
+# cmake codepath when PYOPENMS is set during the initial configure), which
+# is why it can still `rm -rf CMakeFiles` here. CMakeFiles/ adds ~a few
+# hundred MB to the intermediate layer — acceptable.
+RUN rm -rf src doc
 
 # Build pyOpenMS wheels and install via pip.
 RUN make -j4 pyopenms

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -86,8 +86,21 @@ WORKDIR /
 RUN mkdir /openms-build
 WORKDIR /openms-build
 
-# Configure.
-RUN /bin/bash -c "cmake -DCMAKE_BUILD_TYPE='Release' -DCMAKE_PREFIX_PATH='/OpenMS/contrib-build/;/usr/;/usr/local' -DHAS_XSERVER=OFF -DBOOST_USE_STATIC=OFF -DPYOPENMS=ON ../OpenMS -DPY_MEMLEAK_DISABLE=On"
+# Configure (two-pass — mirrors FLASHApp.arm).
+# Pass 1 runs under plain bash so cmake does NOT search /root/miniforge3
+# when resolving C++ system dependencies. On ARM the conda-forge build of
+# libyaml-cpp.so.0.8 is linked against a newer libstdc++ (GLIBCXX_3.4.32,
+# i.e. gcc 13+) than ubuntu:22.04's system g++ ships, so letting cmake
+# pick the miniforge yaml-cpp makes TOPP linking fail with
+#   undefined reference to `std::ios_base_library_init()@GLIBCXX_3.4.32`
+# amd64 happens to work because its conda-forge yaml-cpp build is older.
+# Pass 2 re-runs cmake inside the mamba env with PYOPENMS=ON so the Python
+# bindings can find the conda-forge Python/Cython/NumPy; CMAKE_IGNORE_PREFIX_PATH
+# keeps the C++ link command unchanged from pass 1.
+SHELL ["/bin/bash", "-c"]
+RUN cmake -DCMAKE_BUILD_TYPE='Release' -DCMAKE_PREFIX_PATH='/OpenMS/contrib-build/;/usr/;/usr/local' -DCMAKE_IGNORE_PREFIX_PATH=/root/miniforge3 -DHAS_XSERVER=OFF -DBOOST_USE_STATIC=OFF ../OpenMS
+SHELL ["mamba", "run", "-n", "streamlit-env", "/bin/bash", "-c"]
+RUN cmake -DPYOPENMS=ON -DPY_MEMLEAK_DISABLE=On -DCMAKE_IGNORE_PREFIX_PATH=/root/miniforge3 .
 
 # Build TOPP tools and clean up.
 RUN make -j4 TOPP

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -20,7 +20,7 @@ USER root
 
 # Install required Ubuntu packages.
 RUN apt-get -y update
-RUN apt-get install -y --no-install-recommends --no-install-suggests g++ autoconf automake patch libtool make git gpg wget ca-certificates curl jq libgtk2.0-dev openjdk-8-jdk cron
+RUN apt-get install -y --no-install-recommends --no-install-suggests g++ autoconf automake patch libtool make git gpg wget ca-certificates curl jq libgtk2.0-dev openjdk-8-jdk cron cmake
 RUN update-ca-certificates
 RUN apt-get install -y --no-install-recommends --no-install-suggests libsvm-dev libeigen3-dev coinor-libcbc-dev libglpk-dev libzip-dev zlib1g-dev libxerces-c-dev libbz2-dev libomp-dev libhdf5-dev
 RUN apt-get install -y --no-install-recommends --no-install-suggests libboost-date-time1.74-dev \

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -94,11 +94,15 @@ WORKDIR /openms-build
 # pick the miniforge yaml-cpp makes TOPP linking fail with
 #   undefined reference to `std::ios_base_library_init()@GLIBCXX_3.4.32`
 # amd64 happens to work because its conda-forge yaml-cpp build is older.
+# We call the mamba-env cmake by full path so we get a version >= 3.24
+# (OpenMS 3.5's floor); ubuntu:22.04's apt cmake is 3.22 which is too old.
+# CMAKE_IGNORE_PREFIX_PATH keeps cmake from auto-discovering miniforge libs
+# even though the binary itself lives there.
 # Pass 2 re-runs cmake inside the mamba env with PYOPENMS=ON so the Python
 # bindings can find the conda-forge Python/Cython/NumPy; CMAKE_IGNORE_PREFIX_PATH
 # keeps the C++ link command unchanged from pass 1.
 SHELL ["/bin/bash", "-c"]
-RUN cmake -DCMAKE_BUILD_TYPE='Release' -DCMAKE_PREFIX_PATH='/OpenMS/contrib-build/;/usr/;/usr/local' -DCMAKE_IGNORE_PREFIX_PATH=/root/miniforge3 -DHAS_XSERVER=OFF -DBOOST_USE_STATIC=OFF ../OpenMS
+RUN /root/miniforge3/envs/streamlit-env/bin/cmake -DCMAKE_BUILD_TYPE='Release' -DCMAKE_PREFIX_PATH='/OpenMS/contrib-build/;/usr/;/usr/local' -DCMAKE_IGNORE_PREFIX_PATH=/root/miniforge3 -DHAS_XSERVER=OFF -DBOOST_USE_STATIC=OFF ../OpenMS
 SHELL ["mamba", "run", "-n", "streamlit-env", "/bin/bash", "-c"]
 RUN cmake -DPYOPENMS=ON -DPY_MEMLEAK_DISABLE=On -DCMAKE_IGNORE_PREFIX_PATH=/root/miniforge3 .
 

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -1,0 +1,211 @@
+# This Dockerfile builds OpenMS, the TOPP tools, pyOpenMS and thidparty tools.
+# It also adds a basic streamlit server that serves a pyOpenMS-based app.
+# hints:
+# build image and give it a name (here: streamlitapp) with: docker build -f Dockerfile.arm --no-cache -t streamlitapp:latest-arm64 --build-arg GITHUB_TOKEN=<your-github-token> . 2>&1 | tee build.log
+# check if image was build: docker image ls
+# run container: docker run -p 8501:8501 streamlitappsimple:latest
+# debug container after build (comment out ENTRYPOINT) and run container with interactive /bin/bash shell
+# prune unused images/etc. to free disc space (e.g. might be needed on gitpod). Use with care.: docker system prune --all --force
+
+FROM ubuntu:22.04 AS setup-build-system
+ARG OPENMS_REPO=https://github.com/OpenMS/OpenMS.git
+ARG OPENMS_BRANCH=release/3.5.0
+ARG PORT=8501
+# Streamlit app GitHub user name (to download artifact from).
+ARG GITHUB_USER=OpenMS
+# Streamlit app GitHub repository name (to download artifact from).
+ARG GITHUB_REPO=streamlit-template
+
+USER root
+
+# Install required Ubuntu packages.
+RUN apt-get -y update
+RUN apt-get install -y --no-install-recommends --no-install-suggests g++ autoconf automake patch libtool make git gpg wget ca-certificates curl jq libgtk2.0-dev openjdk-8-jdk cron
+RUN update-ca-certificates
+RUN apt-get install -y --no-install-recommends --no-install-suggests libsvm-dev libeigen3-dev coinor-libcbc-dev libglpk-dev libzip-dev zlib1g-dev libxerces-c-dev libbz2-dev libomp-dev libhdf5-dev
+RUN apt-get install -y --no-install-recommends --no-install-suggests libboost-date-time1.74-dev \
+                                                                     libboost-iostreams1.74-dev \
+                                                                     libboost-regex1.74-dev \
+                                                                     libboost-math1.74-dev \
+                                                                     libboost-random1.74-dev
+RUN apt-get install -y --no-install-recommends --no-install-suggests qt6-base-dev libqt6svg6-dev libqt6opengl6-dev libqt6openglwidgets6 libgl-dev
+
+# Install Github CLI
+RUN (type -p wget >/dev/null || (apt-get update && apt-get install wget -y)) \
+	&& mkdir -p -m 755 /etc/apt/keyrings \
+	&& wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+	&& chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+	&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+	&& apt-get update \
+	&& apt-get install gh -y
+
+# Download and install miniforge.
+ENV PATH="/root/miniforge3/bin:${PATH}"
+RUN wget -q \
+    https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-aarch64.sh \
+    && bash Miniforge3-Linux-aarch64.sh -b \
+    && rm -f Miniforge3-Linux-aarch64.sh
+RUN mamba --version
+
+# Make /root traversable so the entrypoint can `source
+# /root/miniforge3/bin/activate ...` when the container runs as a non-root
+# user (apptainer/singularity maps the host UID into the container; the
+# default ubuntu /root is 0700 which would block path traversal). +x only,
+# not +r, so the directory listing remains private.
+RUN chmod o+x /root
+
+# Setup mamba environment.
+RUN mamba create -n streamlit-env python=3.10
+RUN echo "mamba activate streamlit-env" >> ~/.bashrc
+SHELL ["/bin/bash", "--rcfile", "~/.bashrc"]
+SHELL ["mamba", "run", "-n", "streamlit-env", "/bin/bash", "-c"]
+
+# Install up-to-date cmake via mamba and packages for pyOpenMS build.
+RUN mamba install cmake
+RUN pip install --upgrade pip && python -m pip install -U setuptools nose cython "autowrap<=0.24" pandas numpy pytest
+
+# Clone OpenMS branch and the associcated contrib+thirdparties+pyOpenMS-doc submodules.
+RUN git clone --recursive --depth=1 -b ${OPENMS_BRANCH} --single-branch ${OPENMS_REPO} && cd /OpenMS
+
+# Pull Linux compatible third-party dependencies and store them in directory thirdparty.
+WORKDIR /OpenMS
+RUN mkdir /thirdparty && \
+    git submodule update --init THIRDPARTY && \
+    cp -r THIRDPARTY/All/* /thirdparty && \
+    if [ -d "THIRDPARTY/Linux/aarch64" ]; then \
+        cp -r THIRDPARTY/Linux/aarch64/* /thirdparty; \
+    fi && \
+    chmod -R +x /thirdparty
+ENV PATH="/thirdparty/LuciPHOr2:/thirdparty/MSGFPlus:/thirdparty/ThermoRawFileParser:/thirdparty/Comet:/thirdparty/Percolator:/thirdparty/Sage:${PATH}"
+
+# Build OpenMS and pyOpenMS.
+FROM setup-build-system AS compile-openms
+WORKDIR /
+
+# Set up build directory.
+RUN mkdir /openms-build
+WORKDIR /openms-build
+
+# Configure.
+RUN /bin/bash -c "cmake -DCMAKE_BUILD_TYPE='Release' -DCMAKE_PREFIX_PATH='/OpenMS/contrib-build/;/usr/;/usr/local' -DHAS_XSERVER=OFF -DBOOST_USE_STATIC=OFF -DPYOPENMS=ON ../OpenMS -DPY_MEMLEAK_DISABLE=On"
+
+# Build TOPP tools and clean up.
+RUN make -j4 TOPP
+RUN rm -rf src doc CMakeFiles
+
+# Build pyOpenMS wheels and install via pip.
+RUN make -j4 pyopenms
+WORKDIR /openms-build/pyOpenMS
+RUN pip install dist/*.whl
+
+# Install other dependencies (excluding pyopenms)
+COPY requirements.txt ./requirements.txt 
+RUN grep -Ev '^pyopenms([=<>!~].*)?$' requirements.txt > requirements_cleaned.txt && mv requirements_cleaned.txt requirements.txt
+RUN pip install -r requirements.txt
+
+WORKDIR /
+RUN mkdir openms
+
+# Copy TOPP tools bin directory, add to PATH.
+RUN cp -r openms-build/bin /openms/bin
+ENV PATH="/openms/bin/:${PATH}"
+
+# Copy TOPP tools bin directory, add to PATH.
+RUN cp -r openms-build/lib /openms/lib
+ENV LD_LIBRARY_PATH="/openms/lib/:${LD_LIBRARY_PATH}"
+
+# Copy share folder, add to PATH, remove source directory.
+RUN cp -r OpenMS/share/OpenMS /openms/share
+RUN rm -rf OpenMS
+ENV OPENMS_DATA_PATH="/openms/share/"
+
+# Remove build directory.
+RUN rm -rf openms-build
+
+# Prepare and run streamlit app.
+FROM compile-openms AS run-app
+
+# Install Redis server for job queue and nginx for load balancing.
+# Redis data lives under $RUNTIME_DIR at runtime (see entrypoint.sh) so no
+# /var/lib/redis setup is needed - that path is not writable under Apptainer.
+RUN apt-get update && apt-get install -y --no-install-recommends redis-server nginx \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create Redis data directory. Default 0755 root-owned is enough: the docker
+# entrypoint runs as root (can write regardless of mode), and the apptainer
+# entrypoint relocates Redis state to /tmp/openms-runtime-* so this dir is
+# never written under apptainer.
+RUN mkdir -p /var/lib/redis
+
+# Pre-create bind-mount targets so apptainer/singularity has a real attach
+# point. Docker auto-creates missing `-v` targets, but singularity uses a
+# read-only underlay and silently ignores `:rw` when the target isn't a
+# real directory in the SIF — writes then fail with EROFS even though the
+# host bind path is writable. Pre-creating these directories costs one
+# inode each and changes nothing in docker mode (the user's volume mount
+# shadows them).
+RUN mkdir -p /workspaces-streamlit-template /mounted-data
+
+# Create workdir and copy over all streamlit related files/folders.
+
+# note: specifying folder with slash as suffix and repeating the folder name seems important to preserve directory structure
+WORKDIR /app
+COPY assets/ /app/assets
+COPY content/ /app/content
+COPY docs/ /app/docs
+COPY example-data/ /app/example-data
+COPY gdpr_consent/ /app/gdpr_consent
+COPY hooks/ /app/hooks
+COPY src/ /app/src
+COPY utils/ /app/utils
+COPY app.py /app/app.py
+COPY settings.json /app/settings.json
+COPY default-parameters.json /app/default-parameters.json
+COPY presets.json /app/presets.json
+
+# For streamlit configuration
+COPY .streamlit/ /app/.streamlit/
+COPY clean-up-workspaces.py /app/clean-up-workspaces.py
+
+# add cron job to the crontab
+RUN echo "0 3 * * * /root/miniforge3/envs/streamlit-env/bin/python /app/clean-up-workspaces.py >> /app/clean-up-workspaces.log 2>&1" | crontab -
+
+# Set default worker count (can be overridden via environment variable)
+ENV RQ_WORKER_COUNT=1
+ENV REDIS_URL=redis://localhost:6379/0
+
+# Number of Streamlit server instances for load balancing (default: 1 = no load balancer)
+# Set to >1 to enable nginx load balancer with multiple Streamlit instances
+ENV STREAMLIT_SERVER_COUNT=1
+
+# Install the apptainer-compatible entrypoint that starts cron (when the root
+# FS is writable), Redis, RQ workers, optional nginx load balancer, and the
+# Streamlit server. The script falls back to /tmp paths under apptainer.
+COPY docker/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+# Patch Analytics
+RUN mamba run -n streamlit-env python hooks/hook-analytics.py
+
+# Set Online Deployment
+RUN jq '.online_deployment = true' settings.json > tmp.json && mv tmp.json settings.json
+
+# Point the in-app mounted-drive browser at the conventional bind-mount path.
+# The browser only renders when this directory exists at runtime, i.e. when
+# the user starts the container with `-v /host/path:/mounted-data`.
+RUN jq '.local_data_dir = "/mounted-data"' settings.json > tmp.json && mv tmp.json settings.json
+
+# Download latest OpenMS App executable as a ZIP file.
+# ARG declared here (not at the top) — otherwise the per-run token busts the cache.
+ARG GITHUB_TOKEN
+RUN if [ -n "$GITHUB_TOKEN" ]; then \
+        echo "GITHUB_TOKEN is set, proceeding to download the release asset..."; \
+        gh release download -R ${GITHUB_USER}/${GITHUB_REPO} -p "OpenMS-App.zip" -D /app; \
+    else \
+        echo "GITHUB_TOKEN is not set, skipping the release asset download."; \
+    fi
+
+
+# Run app as container entrypoint.
+EXPOSE $PORT
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/Dockerfile_simple.arm
+++ b/Dockerfile_simple.arm
@@ -1,0 +1,127 @@
+# This Dockerfile creates a container with pyOpenMS
+# It also adds a basic streamlit server that serves a pyOpenMS-based app.
+# hints:
+# build image with: docker build -f Dockerfile_simple.arm --no-cache -t streamlitapp:latest-arm64 --build-arg GITHUB_TOKEN=<your-github-token> . 2>&1 | tee build.log
+# check if image was build: docker image ls
+# run container: docker run -p 8501:8501 streamlitapp:latest
+# debug container after build (comment out ENTRYPOINT) and run container with interactive /bin/bash shell
+# prune unused images/etc. to free disc space (e.g. might be needed on gitpod). Use with care.: docker system prune --all --force
+
+FROM ubuntu:22.04 AS stage1
+ARG OPENMS_REPO=https://github.com/OpenMS/OpenMS.git
+ARG OPENMS_BRANCH=develop
+ARG PORT=8501
+# Streamlit app GitHub user name (to download artifact from).
+ARG GITHUB_USER=OpenMS
+# Streamlit app GitHub repository name (to download artifact from).
+ARG GITHUB_REPO=streamlit-template
+
+
+# Step 1: set up a sane build system
+USER root
+
+RUN apt-get -y update
+# note: streamlit in docker needs libgtk2.0-dev (see https://yugdamor.medium.com/importerror-libgthread-2-0-so-0-cannot-open-shared-object-file-no-such-file-or-directory-895b94a7827b)
+RUN apt-get install -y --no-install-recommends --no-install-suggests wget ca-certificates libgtk2.0-dev curl jq cron nginx
+RUN update-ca-certificates
+
+# Install Github CLI
+RUN (type -p wget >/dev/null || (apt-get update && apt-get install wget -y)) \
+	&& mkdir -p -m 755 /etc/apt/keyrings \
+	&& wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+	&& chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+	&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+	&& apt-get update \
+	&& apt-get install gh -y
+
+# Download and install miniforge.
+ENV PATH="/root/miniforge3/bin:${PATH}"
+RUN wget -q \
+    https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-aarch64.sh \
+    && bash Miniforge3-Linux-aarch64.sh -b \
+    && rm -f Miniforge3-Linux-aarch64.sh
+RUN mamba --version
+
+# Make /root traversable so the entrypoint can `source
+# /root/miniforge3/bin/activate ...` when the container runs as a non-root
+# user (apptainer/singularity maps the host UID into the container; the
+# default ubuntu /root is 0700 which would block path traversal). +x only,
+# not +r, so the directory listing remains private.
+RUN chmod o+x /root
+
+# Setup mamba environment.
+RUN mamba create -n streamlit-env python=3.10 
+RUN echo "mamba activate streamlit-env" >> ~/.bashrc
+SHELL ["/bin/bash", "--rcfile", "~/.bashrc"]
+SHELL ["mamba", "run", "-n", "streamlit-env", "/bin/bash", "-c"]
+
+#################################### install streamlit
+# install packages
+COPY requirements.txt requirements.txt
+RUN mamba install pip
+RUN python -m pip install --upgrade pip
+RUN python -m pip install -r requirements.txt
+
+# Pre-create bind-mount targets so apptainer/singularity has a real attach
+# point. Docker auto-creates missing `-v` targets, but singularity uses a
+# read-only underlay and silently ignores `:rw` when the target isn't a
+# real directory in the SIF — writes then fail with EROFS even though the
+# host bind path is writable.
+RUN mkdir -p /workspaces-streamlit-template /mounted-data
+
+# create workdir and copy over all streamlit related files/folders
+WORKDIR /app
+# note: specifying folder with slash as suffix and repeating the folder name seems important to preserve directory structure
+WORKDIR /app
+COPY assets/ /app/assets
+COPY content/ /app/content
+COPY docs/ /app/docs
+COPY example-data/ /app/example-data
+COPY gdpr_consent/ /app/gdpr_consent
+COPY hooks/ /app/hooks
+COPY src/ /app/src
+COPY utils/ /app/utils
+COPY app.py /app/app.py
+COPY settings.json /app/settings.json
+COPY default-parameters.json /app/default-parameters.json
+COPY presets.json /app/presets.json
+
+# For streamlit configuration
+COPY .streamlit/ /app/.streamlit/
+
+COPY clean-up-workspaces.py /app/clean-up-workspaces.py
+
+# add cron job to the crontab
+RUN echo "0 3 * * * /root/miniforge3/envs/streamlit-env/bin/python /app/clean-up-workspaces.py >> /app/clean-up-workspaces.log 2>&1" | crontab -
+
+# Number of Streamlit server instances for load balancing (default: 1 = no load balancer)
+# Set to >1 to enable nginx load balancer with multiple Streamlit instances
+ENV STREAMLIT_SERVER_COUNT=1
+
+# Install the apptainer-compatible entrypoint (shared with the full image).
+# The script auto-skips the Redis/RQ section when redis-server is not
+# installed, so it works equally well in the simple variant.
+COPY docker/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+# Patch Analytics
+RUN mamba run -n streamlit-env python hooks/hook-analytics.py
+
+# Set Online Deployment
+RUN jq '.online_deployment = true' settings.json > tmp.json && mv tmp.json settings.json
+
+# Download latest OpenMS App executable as a ZIP file.
+# ARG declared here (not at the top) — otherwise the per-run token busts the cache.
+ARG GITHUB_TOKEN
+RUN if [ -n "$GITHUB_TOKEN" ]; then \
+        echo "GITHUB_TOKEN is set, proceeding to download the release asset..."; \
+        gh release download -R ${GITHUB_USER}/${GITHUB_REPO} -p "OpenMS-App.zip" -D /app; \
+    else \
+        echo "GITHUB_TOKEN is not set, skipping the release asset download."; \
+    fi
+
+# make sure that mamba environment is used
+SHELL ["mamba", "run", "-n", "streamlit-env", "/bin/bash", "-c"]
+
+EXPOSE $PORT
+ENTRYPOINT ["/app/entrypoint.sh"]


### PR DESCRIPTION
## Summary

This PR adds native ARM64 (aarch64) Docker image builds alongside existing AMD64 builds, enabling the streamlit-template to run on ARM-based systems (Apple Silicon, AWS Graviton, Raspberry Pi, etc.). The changes implement a multi-architecture build pipeline that produces per-arch images and stitches them into a unified multi-arch manifest for transparent architecture selection on pull.

## Key Changes

- **New Dockerfiles for ARM64**:
  - `Dockerfile.arm` — Full build with OpenMS, TOPP tools, and pyOpenMS (aarch64 variant)
  - `Dockerfile_simple.arm` — Lightweight pyOpenMS-only build (aarch64 variant)
  - Both swap the miniforge installer from x86_64 to aarch64 and conditionally copy `THIRDPARTY/Linux/aarch64` dependencies

- **CI/CD Pipeline Restructuring** (`.github/workflows/build-and-test.yml`):
  - Renamed `build` job to `build-amd64` for clarity
  - Added new `build-arm64` job that runs on native ARM64 runner (`ubuntu-24.04-arm`)
  - Per-arch tags now include `-amd64` / `-arm64` suffixes (e.g., `main-full-amd64`, `main-full-arm64`)
  - New `create-manifest` job stitches per-arch tags into multi-arch manifests under the original tag scheme (e.g., `main-full`, `latest`)
  - ARM64 build includes disk space cleanup and smoke test (health endpoint validation)
  - Test jobs (`test-apptainer`, `test-nginx`, `test-traefik`) remain AMD64-only for now

- **Manifest Strategy**:
  - Per-arch images tagged with architecture suffix for traceability
  - Multi-arch manifests reuse pre-ARM64 tag scheme so existing consumers (k8s overlays, docker-compose, `docker pull` callers) continue working transparently
  - Docker automatically selects the correct architecture on pull

## Implementation Details

- ARM64 runner uses `ubuntu-24.04-arm` (native, no QEMU emulation)
- Miniforge installer URL swapped to `Miniforge3-Linux-aarch64.sh` in ARM Dockerfiles
- THIRDPARTY/Linux/aarch64 copy guarded with conditional check (only copies if directory exists)
- ARM64 build includes `provenance: false` to avoid attestation overhead on native runner
- Smoke test on ARM64 validates entrypoint and Streamlit health endpoint post-push
- Cache keys include `-amd64` / `-arm64` suffix to prevent cross-arch cache pollution
- PR builds validate Dockerfile syntax and compilation but don't push per-arch tags (no manifest to create)

## Backward Compatibility

Existing image references (`:main-full`, `:latest`, `:v1.0.0-full`) continue to work unchanged — they now resolve to multi-arch manifests that auto-select the correct architecture. No breaking changes to consumers.

https://claude.ai/code/session_01G3xxGELawVjFLSLy9NEg3R

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ARM64 image variants and corresponding multi-architecture manifests.
  * Added ARM64-ready container images for the app (build + runtime) including service defaults, mount points, scheduled cleanup, and optional release asset download.

* **Chores**
  * CI split into separate amd64/arm64 build jobs; artifact naming and test matrices updated.

* **Improvements**
  * Expanded integration tests across architectures and added cluster-state dumps on failure; Apptainer test remains amd64 and frees disk before loading artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenMS/streamlit-template/pull/393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->