### PR TITLE
Pin cython below 3.3 so the full image builds again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ SHELL ["mamba", "run", "-n", "streamlit-env", "/bin/bash", "-c"]
 
 # Install up-to-date cmake via mamba and packages for pyOpenMS build.
 RUN mamba install cmake
-RUN pip install --upgrade pip && python -m pip install -U setuptools nose cython "autowrap<=0.24" pandas numpy pytest
+RUN pip install --upgrade pip && python -m pip install -U setuptools nose "cython>=3.1.0,<3.3" "autowrap<=0.24" pandas numpy pytest
 
 # Clone OpenMS branch and the associcated contrib+thirdparties+pyOpenMS-doc submodules.
 RUN git clone --recursive --depth=1 -b ${OPENMS_BRANCH} --single-branch ${OPENMS_REPO} && cd /OpenMS

--- a/Dockerfile.arm
+++ b/Dockerfile.arm
@@ -62,7 +62,7 @@ SHELL ["mamba", "run", "-n", "streamlit-env", "/bin/bash", "-c"]
 
 # Install up-to-date cmake via mamba and packages for pyOpenMS build.
 RUN mamba install cmake
-RUN pip install --upgrade pip && python -m pip install -U setuptools nose cython "autowrap<=0.24" pandas numpy pytest
+RUN pip install --upgrade pip && python -m pip install -U setuptools nose "cython>=3.1.0,<3.3" "autowrap<=0.24" pandas numpy pytest
 
 # Clone OpenMS branch and the associcated contrib+thirdparties+pyOpenMS-doc submodules.
 RUN git clone --recursive --depth=1 -b ${OPENMS_BRANCH} --single-branch ${OPENMS_REPO} && cd /OpenMS


### PR DESCRIPTION
Both `full`-variant image builds have failed on `main` and on every open branch since 2026-08-25:

```
AttributeError: module 'Cython.Compiler.Nodes' has no attribute 'CConstTypeNode'.
  Did you mean: 'CBaseTypeNode'?
...
buildx failed: process "mamba run -n streamlit-env /bin/bash -c make -j4 pyopenms"
  did not complete successfully: exit code: 2
```

## Cause

`Dockerfile:65` and `Dockerfile.arm:65` pin `autowrap` but leave `cython` unpinned:

```
RUN pip install --upgrade pip && python -m pip install -U setuptools nose cython "autowrap<=0.24" pandas numpy pytest
```

**cython 3.3.0** was released on 2026-08-22 and removed `Cython.Compiler.Nodes.CConstTypeNode` and `CConstOrVolatileTypeNode`, which autowrap 0.24's `PXDParser._check_type_constness` calls while generating the pyOpenMS bindings.

| date | resolved | result |
|---|---|---|
| 2026-08-21 | `autowrap-0.24.0 cython-3.2.9` | green |
| 2026-08-25 | `autowrap-0.24.0 cython-3.3.0` | red, both arches |

## Fix

`cython>=3.1.0,<3.3`. `3.2.9` is the last 3.2.x on PyPI, so this restores exactly the resolution that was green on 2026-08-21. The lower bound matches what pyOpenMS asserts for itself during the build (`Cython>=3.1.0 is installed`).

## Why not bump autowrap instead

The newest autowrap release is **0.27.0, uploaded 2026-01-14** — seven months *before* cython 3.3.0 — and it declares only `Cython >= 3.0`, an open upper bound with no knowledge of the removed AST nodes. No published autowrap can be assumed to handle them, and a build that happened to succeed would silently change the generated bindings.

## Verifying

`build-amd64 (full)` and `build-arm64 (full)` conclude `success`, and their logs contain `Successfully installed autowrap-0.24.0 cython-3.2.9` rather than a 3.3.x.

---

Split out of #399, which cannot be validated until this lands: the broken `full` build was skipping the entire kind integration suite there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability by constraining Cython to a compatible version range in standard and ARM container environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->