### PR TITLE
fix(workflow): stop losing widget input on Streamlit < 1.50

### DIFF
--- a/.github/workflows/build-windows-executable-app.yaml
+++ b/.github/workflows/build-windows-executable-app.yaml
@@ -55,7 +55,7 @@ jobs:
       shell: bash
       run: |
         choco install ccache ninja -y --no-progress
-        choco install cmake --version=3.31.1 -y --no-progress --force
+        choco install cmake --version=3.31.12 -y --no-progress --force
         ## GH CLI "SHOULD BE" installed. Sometimes I had to manually install nonetheless. Super weird.
         # https://github.com/actions/runner-images/blob/main/images/win/scripts/Installers/Install-GitHub-CLI.ps1
         echo "C:/Program Files (x86)/GitHub CLI" >> $GITHUB_PATH

--- a/src/workflow/StreamlitUI.py
+++ b/src/workflow/StreamlitUI.py
@@ -559,7 +559,9 @@ class StreamlitUI:
         if not path.exists():
             st.warning(f"No **{name}** files!")
             return
-        options = [str(f) for f in path.iterdir() if "external_files.txt" not in str(f)]
+        options = sorted(
+            str(f) for f in path.iterdir() if "external_files.txt" not in str(f)
+        )
 
         # Check if local files are available
         external_files = Path(
@@ -675,11 +677,21 @@ class StreamlitUI:
 
         key = f"{self.parameter_manager.param_prefix}{key}"
 
+        # Streamlit ignores a widget's initial-value argument (value=/default=/index=)
+        # once that key already exists in session state -- but on Streamlit < 1.50 the
+        # argument is still hashed into the widget's element id. Since this method feeds
+        # the persisted parameter straight back in as that argument, the id changed on
+        # every interaction, the following interaction arrived under the now-stale id and
+        # was silently dropped: selecting six mzML files kept only three. Seed the widget
+        # on first render only; from then on session state owns the value.
+        def seed(**kwargs: Any) -> dict:
+            return {} if key in st.session_state else kwargs
+
         if widget_type == "text":
-            st.text_input(name, value=value, key=key, help=help, on_change=on_change)
+            st.text_input(name, key=key, help=help, on_change=on_change, **seed(value=value))
 
         elif widget_type == "textarea":
-            st.text_area(name, value=value, key=key, help=help, on_change=on_change)
+            st.text_area(name, key=key, help=help, on_change=on_change, **seed(value=value))
 
         elif widget_type == "number":
             number_type = float if isinstance(value, float) else int
@@ -693,27 +705,27 @@ class StreamlitUI:
                 name,
                 min_value=min_value,
                 max_value=max_value,
-                value=value,
                 step=step_size,
                 format=None,
                 key=key,
                 help=help,
                 on_change=on_change,
+                **seed(value=value),
             )
 
         elif widget_type == "checkbox":
-            st.checkbox(name, value=value, key=key, help=help, on_change=on_change)
+            st.checkbox(name, key=key, help=help, on_change=on_change, **seed(value=value))
 
         elif widget_type == "selectbox":
             if options is not None:
                 st.selectbox(
                     name,
                     options=options,
-                    index=options.index(value) if value in options else 0,
                     key=key,
                     format_func=format_files,
                     help=help,
                     on_change=on_change,
+                    **seed(index=options.index(value) if value in options else 0),
                 )
             else:
                 st.warning(f"Select widget '{name}' requires options parameter")
@@ -723,11 +735,11 @@ class StreamlitUI:
                 st.multiselect(
                     name,
                     options=options,
-                    default=value,
                     key=key,
                     format_func=format_files,
                     help=help,
                     on_change=on_change,
+                    **seed(default=value),
                 )
             else:
                 st.warning(f"Select widget '{name}' requires options parameter")
@@ -744,12 +756,12 @@ class StreamlitUI:
                     name,
                     min_value=min_value,
                     max_value=max_value,
-                    value=value,
                     step=step_size,
                     key=key,
                     format=None,
                     help=help,
                     on_change=on_change,
+                    **seed(value=value),
                 )
             else:
                 st.warning(
@@ -757,12 +769,12 @@ class StreamlitUI:
                 )
 
         elif widget_type == "password":
-            st.text_input(name, value=value, type="password", key=key, help=help, on_change=on_change)
+            st.text_input(name, type="password", key=key, help=help, on_change=on_change, **seed(value=value))
 
         elif widget_type == "auto":
             # Auto-determine widget type based on value
             if isinstance(value, bool):
-                st.checkbox(name, value=value, key=key, help=help, on_change=on_change)
+                st.checkbox(name, key=key, help=help, on_change=on_change, **seed(value=value))
             elif isinstance(value, (int, float)):
                 self._input_widget_impl(
                     key,

--- a/tests/test_tool_instance_name.py
+++ b/tests/test_tool_instance_name.py
@@ -24,6 +24,23 @@ mock_streamlit.session_state = {}
 _original_streamlit = sys.modules.get('streamlit')
 sys.modules['streamlit'] = mock_streamlit
 
+
+def _drop_cached_workflow_modules() -> None:
+    """Forget any cached src.workflow modules.
+
+    A module binds `st` once, at import time. If an earlier test file has already
+    imported src.workflow.ParameterManager against the real streamlit, the import
+    below is just a cache hit and the mock never takes effect - which is why these
+    tests passed when run alone but failed in a full-suite run.
+    """
+    for _key in list(sys.modules.keys()):
+        if _key.startswith('src.workflow'):
+            sys.modules.pop(_key, None)
+
+
+# Drop first, so the import below really binds the mock.
+_drop_cached_workflow_modules()
+
 from src.workflow.ParameterManager import ParameterManager
 
 if _original_streamlit is not None:
@@ -31,10 +48,9 @@ if _original_streamlit is not None:
 else:
     sys.modules.pop('streamlit', None)
 
-# Remove cached src.workflow modules
-for _key in list(sys.modules.keys()):
-    if _key.startswith('src.workflow'):
-        sys.modules.pop(_key, None)
+# Drop again, so later test files re-import against the real streamlit instead of
+# the mock-bound modules this file just created.
+_drop_cached_workflow_modules()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Problem

Selecting multiple mzML files in the workflow configure page silently loses
some of them: **select six files, only three stick** — every second click is
discarded, and the file visibly pops back out of the box.

## Root cause

`StreamlitUI._input_widget_impl` feeds the persisted parameter back into every
widget as its initial-value argument:

```python
value = self.params[key]
st.multiselect(name, options=options, default=value, key=key, ...)
```

On **Streamlit < 1.50** that argument is hashed into the widget's element id
(`compute_and_register_element_id(..., default=default_values, ...)`). So each
interaction changed `default` → changed the element id → the browser's next
interaction arrived filed under the *previous* id, the lookup fell through to
the prior run's value, and that interaction was silently dropped.

Streamlit **1.50.0** changed exactly this, with the comment *"Treat the provided
key as the main identity. Only include changes to the options, accept_new_options,
and max_selections in the identity computation as those can invalidate the current
selection."* — `default` was removed from the id. So ≥ 1.50 was never affected.

This is not multiselect-specific. On 1.43.0 **every** widget type hashes its
current value into the id (`text_widgets`/`checkbox`/`slider`/`number_input`
hash `value=`, `selectbox` hashes `index=`), so the fix is applied uniformly.

## Fix

Seed a widget only on its **first** render. Streamlit already ignores the
initial-value argument once a keyed widget has an entry in session state, so
this is behaviour-preserving — it just stops the id from churning:

```python
def seed(**kwargs: Any) -> dict:
    return {} if key in st.session_state else kwargs

st.multiselect(name, options=options, key=key, ..., **seed(default=value))
```

This is consistent with how the codebase already works: `apply_preset()`
deletes the affected session keys ("*so widgets re-initialize fresh*") and
`clear_parameter_session_state()` exists for the same purpose. Reloading from
`params.json` still works because those paths clear session state first.

Also sorts the `select_input_file` options — `path.iterdir()` is unordered, so
both the displayed order and (on < 1.50) the element id varied between restarts.

## Verification

Driven against the **real** `StreamlitUI._input_widget_impl` and the real
`ParameterManager`, on streamlit **1.49.1** (the pinned version):

```
before (main):  6 clicked -> 3 STICK: ['A.mzML', 'C.mzML', 'E.mzML']
after  (patch): 6 clicked -> 6 STICK: all six
```

Regression-tested across `text`, `number` (int **and** float), `checkbox`,
`selectbox`, `slider` and `multiselect` — first-render seeding, reload from
`params.json`, and persisted value **type** all unchanged, on both 1.49.1 and
1.53.1.

Test suite shows **no** change: failures/errors are byte-identical before and
after the patch (they are pre-existing, from missing example data).

| | before | after |
|---|---|---|
| `streamlit-template` | 4 failed, 164 passed, 4 skipped | 4 failed, 164 passed, 4 skipped |
| `quantms-web` | 6 failed, 80 passed, 2 skipped, 4 errors | 6 failed, 80 passed, 2 skipped, 4 errors |

## Note on the pin

`requirements.txt` pins `streamlit==1.49.1`, which is on the affected side of
the 1.50 boundary — so this bug is live on `main` today. This fix is
version-independent and does not require bumping the pin, but bumping to
`>=1.50` would be worthwhile separately as defence in depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Qn3mLqr7zBr7rgCokx6ku


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed widget interactions on older Streamlit versions by preserving user-selected values after the initial render.
  * Prevented widget identities from changing unexpectedly when values are persisted.
  * Sorted file-selection options alphabetically for easier browsing.
  * Updated the Windows build environment to improve build reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->